### PR TITLE
Hide light axis if all light datasets are hidden

### DIFF
--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -283,23 +283,28 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
                 },
                 legend: {
                   onClick: (event, legendItem, legend) => {
-                    let visibleToSet = false;
                     if (legendItem.datasetIndex !== undefined) {
                       if (!legendItem.hidden) {
                         legend.chart.hide(legendItem.datasetIndex);
-                        visibleToSet = false;
+                        setDataSets((prev) =>
+                          prev.map((prevDataSet) =>
+                            prevDataSet.id === legendItem.datasetIndex
+                              ? { ...prevDataSet, visible: false }
+                              : prevDataSet
+                          )
+                        );
+                        legend.chart.update("hide");
                       } else {
                         legend.chart.show(legendItem.datasetIndex);
-                        visibleToSet = true;
+                        setDataSets((prev) =>
+                          prev.map((prevDataSet) =>
+                            prevDataSet.id === legendItem.datasetIndex
+                              ? { ...prevDataSet, visible: true }
+                              : prevDataSet
+                          )
+                        );
+                        legend.chart.update("show");
                       }
-                      setDataSets((prev) =>
-                        prev.map((prevDataSet) =>
-                          prevDataSet.id === legendItem.datasetIndex
-                            ? { ...prevDataSet, visible: visibleToSet }
-                            : prevDataSet
-                        )
-                      );
-                      legend.chart.update();
                     }
                   },
                 },


### PR DESCRIPTION
- In case all the light datasets have been hidden in MultiSensorGraph, hide the light axis.
- As part of this, moved the datasets to a state variable in MultiSensorGraph. The variable gets updated the model changes.