### PR TITLE
Initial version of build/release pipeline for the function app

### DIFF
--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -1,9 +1,6 @@
 name: Build & deploy Environment Monitor function app
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -1,10 +1,16 @@
 name: Build and deploy environment-monitor (Azure Function)
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy?"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 env:
   DOTNET_VERSION: "8.0.x"
@@ -32,9 +38,11 @@ jobs:
         with:
           name: .env-monitor-function-app
           path: "./output"
+          include-hidden-files: true
 
       - name: Login to Azure
         uses: azure/login@v2
+        if: inputs.deploy == 'true'
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_4C8625311A7E41DF94B1F493E439AE3D }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_A9F03B52F6CA485B82924F1970E00D80 }}
@@ -42,6 +50,7 @@ jobs:
 
       - name: "Deploy HubObserver"
         uses: Azure/functions-action@v1
+        if: inputs.deploy == 'true'
         id: fa
         with:
           app-name: "EnvironmentMonitorHubObserver"

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -1,4 +1,4 @@
-name: Build & deploy Environment Monitor function app
+name: Build and deploy environment-monitor (Azure Function)
 
 on:
   push:

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Build Environment Monitor function app
+      - name: Build HubObserver
         run: dotnet build src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj --configuration Release -o ./output
 
-      - name: Upload function app
+      - name: Upload HubObserver
         uses: actions/upload-artifact@v4
         with:
           name: .env-monitor-function-app
@@ -40,7 +40,7 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_A9F03B52F6CA485B82924F1970E00D80 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_E4CE7A1599994A388FDDA5640CED3ECE }}
 
-      - name: "Deploy function"
+      - name: "Deploy HubObserver"
         uses: Azure/functions-action@v1
         id: fa
         with:

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -1,6 +1,9 @@
 name: Build & deploy Environment Monitor function app
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:
@@ -24,6 +27,12 @@ jobs:
       - name: Build Environment Monitor function app
         run: dotnet build src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj --configuration Release -o ./output
 
+      - name: Upload function app
+        uses: actions/upload-artifact@v4
+        with:
+          name: .env-monitor-function-app
+          path: "./output"
+
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -31,16 +40,10 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_A9F03B52F6CA485B82924F1970E00D80 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_E4CE7A1599994A388FDDA5640CED3ECE }}
 
-      - name: "Release function"
+      - name: "Deploy function"
         uses: Azure/functions-action@v1
         id: fa
         with:
           app-name: "EnvironmentMonitorHubObserver"
           slot-name: "Production"
           package: "./output"
-
-      - name: Upload web api artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: .env-monitor-function-app
-          path: "./output"

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
   DOTNET_VERSION: "8.0.x"
 jobs:
   build:
@@ -22,12 +21,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: "Build Environment Monitor"
-        shell: pwsh
-        run: |
-          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          dotnet build --configuration Release --output ./output
-          popd
+      - name: Build Environment Monitor function app
+        run: dotnet build src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj --configuration Release -o ./output
 
       - name: Login to Azure
         uses: azure/login@v2
@@ -42,7 +37,7 @@ jobs:
         with:
           app-name: "EnvironmentMonitorHubObserver"
           slot-name: "Production"
-          package: "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output"
+          package: "./output"
 
       - name: Upload web api artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -1,1 +1,37 @@
+name: Build & deploy Environment Monitor function app
 
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
+  DOTNET_VERSION: "8.0.x"
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@v4
+
+      - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: "Build Environment Monitor"
+        shell: pwsh
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          dotnet build --configuration Release --output ./output
+          popd
+      - name: Upload web api artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: .env-monitor-function-app
+          path: "./output"

--- a/.github/workflows/function_app_build.yml
+++ b/.github/workflows/function_app_build.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    environment: Production
     permissions:
       id-token: write
       contents: read
@@ -27,6 +28,22 @@ jobs:
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
           dotnet build --configuration Release --output ./output
           popd
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_4C8625311A7E41DF94B1F493E439AE3D }}
+          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_A9F03B52F6CA485B82924F1970E00D80 }}
+          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_E4CE7A1599994A388FDDA5640CED3ECE }}
+
+      - name: "Release function"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: "EnvironmentMonitorHubObserver"
+          slot-name: "Production"
+          package: "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output"
+
       - name: Upload web api artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -1,4 +1,4 @@
-name: Build and deploy environment-monitor (Web)
+name: Build and deploy environment-monitor
 
 on:
   push:
@@ -25,9 +25,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          # Version Spec of the version to use in SemVer notation.
-          # It also admits such aliases as lts/*, latest, nightly and canary builds
-          # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, 16-nightly, latest, node
           node-version: ">=20.0.0"
 
       - name: Set up .NET Core
@@ -77,6 +74,7 @@ jobs:
         with:
           name: .env-monitor-function
           path: ${{env.DOTNET_ROOT}}/env-monitor-function
+          include-hidden-files: true
   deploy:
     runs-on: windows-latest
     needs: build
@@ -95,6 +93,12 @@ jobs:
           name: .env-monitor-web-api
           path: "./env-monitor-web-api"
 
+      - name: Download HubObserver artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: .env-monitor-function
+          path: "./env-monitor-function"
+
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -109,3 +113,11 @@ jobs:
           app-name: "env-monitor"
           slot-name: "Production"
           package: "./env-monitor-web-api"
+
+      - name: "Deploy HubObserver (Azure function)"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: "EnvironmentMonitorHubObserver"
+          slot-name: "Production"
+          package: "./env-monitor-function"

--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -1,4 +1,4 @@
-name: Build and deploy environment-monitor
+name: Build and deploy environment-monitor (Web)
 
 on:
   push:

--- a/src/EnvironmentMonitor.Application/Services/MeasurementService.cs
+++ b/src/EnvironmentMonitor.Application/Services/MeasurementService.cs
@@ -44,14 +44,14 @@ namespace EnvironmentMonitor.Application.Services
             var device = await _deviceService.GetDevice(measurement.DeviceId, AccessLevels.Write);
             if (device == null)
             {
-                _logger.LogInformation($"Could not find device with device id '{measurement.DeviceId}'");
+                _logger.LogWarning($"Could not find device with device id '{measurement.DeviceId}'");
                 return;
             }
             if (!_userService.HasAccessToDevice(device.Id, AccessLevels.Write))
             {
                 throw new UnauthorizedAccessException("No Access");
             }
-            _logger.LogInformation($"Found device with ID: {device.Id} for device id '{measurement.DeviceId}'");
+            _logger.LogInformation($"Found device with ID: {device.Id} for device identifier '{measurement.DeviceId}'");
             var measurementsToAdd = new List<Measurement>();
             foreach (var row in measurement.Measurements)
             {
@@ -84,13 +84,13 @@ namespace EnvironmentMonitor.Application.Services
             }
             if (measurementsToAdd.Any())
             {
-                _logger.LogInformation($"Adding {measurementsToAdd.Count} measurements for Device: {device.Id} / '{device.Name}'");
+                _logger.LogInformation($"Adding {measurementsToAdd.Count} measurements for Device ({device.Id}): '{device.Name}'");
                 if (measurement.FirstMessage)
                 {
                     await _deviceService.AddEvent(device.Id, DeviceEventTypes.Online, "First message after boot", false, measurement.EnqueuedUtc);
                 }
                 await _measurementRepository.AddMeasurements(measurementsToAdd);
-                _logger.LogInformation("Measurements added");
+                _logger.LogInformation("Measurementsadded");
             }
             else
             {

--- a/src/EnvironmentMonitor.HubObserver/Functions/HubObserver.cs
+++ b/src/EnvironmentMonitor.HubObserver/Functions/HubObserver.cs
@@ -25,13 +25,15 @@ namespace EnvironmentMonitor.HubObserver.Functions
         {
             if (events?.Length > 0)
             {
-                _logger.LogInformation($"Start processing {events.Length} messages");
+                _logger.LogInformation($"Start processing {events.Length} messages.");
             }
             else
             {
                 _logger.LogWarning("No messages to process!");
                 return;
             }
+            var processedMessaged = 0;
+
             foreach (EventData message in events)
             {
                 var bodyString = Encoding.UTF8.GetString(message.EventBody);
@@ -69,6 +71,7 @@ namespace EnvironmentMonitor.HubObserver.Functions
                 try
                 {
                     await _measurementService.AddMeasurements(objectToInsert);
+                    processedMessaged++;
                 }
                 catch (Exception ex)
                 {
@@ -76,6 +79,7 @@ namespace EnvironmentMonitor.HubObserver.Functions
                     throw;
                 }
             }
+            _logger.LogInformation($"Total of {processedMessaged} processed");
         }
     }
 }


### PR DESCRIPTION
- Initial version of build/release pipeline for function app added. The function app specific pipeline handles just the building and deploying of HubObserver (func app). This pipeline is to be triggered only manually at this point.
- The main action also modified so, that it publishes and deploys the function app. The idea is that this pipeline would publish both the apps when something is pushed to the main branch.
- Added some minor logging changes in MeasurementService and the HubObserver-function.