### PR TITLE
Changes / optimization for DeviceInfo fetching

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
@@ -1,17 +1,11 @@
 ﻿using AutoMapper;
 using EnvironmentMonitor.Application.Mappings;
-using EnvironmentMonitor.Domain;
-using EnvironmentMonitor.Domain.Entities;
+using EnvironmentMonitor.Application.ValueResolvers;
 using EnvironmentMonitor.Domain.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EnvironmentMonitor.Application.DTOs
 {
-    public class DeviceInfoDto : IMapFrom<Device>
+    public class DeviceInfoDto : IMapFrom<DeviceInfo>
     {
         public DeviceDto Device { get; set; }
         public DateTime? OnlineSince { get; set; }
@@ -21,7 +15,7 @@ namespace EnvironmentMonitor.Application.DTOs
         public bool ShowWarning { get; set; }
         public void Mapping(Profile profile)
         {
-            profile.CreateMap<DeviceInfo, DeviceInfoDto>().ForMember(x => x.ShowWarning, opt => opt.MapFrom(x => x.LastMessageUtc == null || x.LastMessageUtc < DateTime.UtcNow.AddMinutes(-1 * ApplicationConstants.DeviceWarningLimitInMinutes))).ReverseMap();
+            profile.CreateMap<DeviceInfo, DeviceInfoDto>().ForMember(x => x.ShowWarning, opt => opt.MapFrom<ShowDeviceWarningResolver>()).ReverseMap();
         }
     }
 }

--- a/src/EnvironmentMonitor.Application/ValueResolvers/ShowDeviceWarningResolver.cs
+++ b/src/EnvironmentMonitor.Application/ValueResolvers/ShowDeviceWarningResolver.cs
@@ -1,0 +1,28 @@
+﻿using AutoMapper;
+using EnvironmentMonitor.Application.DTOs;
+using EnvironmentMonitor.Domain;
+using EnvironmentMonitor.Domain.Interfaces;
+using EnvironmentMonitor.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnvironmentMonitor.Application.ValueResolvers
+{
+    public class ShowDeviceWarningResolver : IValueResolver<DeviceInfo, DeviceInfoDto, bool>
+    {
+        private readonly IDateService _dateService;
+
+        public ShowDeviceWarningResolver(IDateService dateService)
+        {
+            _dateService = dateService;
+        }
+
+        public bool Resolve(DeviceInfo source, DeviceInfoDto destination, bool destMember, ResolutionContext context)
+        {
+            return _dateService.CurrentTime().AddMinutes(-1 * ApplicationConstants.DeviceWarningLimitInMinutes) > source.LastMessage;
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Domain/Models/DeviceInfo.cs
+++ b/src/EnvironmentMonitor.Domain/Models/DeviceInfo.cs
@@ -1,9 +1,4 @@
 ﻿using EnvironmentMonitor.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EnvironmentMonitor.Domain.Models
 {
@@ -12,8 +7,6 @@ namespace EnvironmentMonitor.Domain.Models
         public Device Device { get; set; }
         public DateTime? OnlineSince { get; set; }
         public DateTime? RebootedOn { get; set; }
-
         public DateTime? LastMessage { get; set; }
-        public DateTime? LastMessageUtc { get; set; }
     }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -111,8 +111,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
                 Device = device,
                 OnlineSince = query.FirstOrDefault(x => x.DeviceId == device.Id && x.TypeId == (int)DeviceEventTypes.Online)?.TimeStamp,
                 RebootedOn = query.FirstOrDefault(x => x.DeviceId == device.Id && x.TypeId == (int)DeviceEventTypes.RebootCommand)?.TimeStamp,
-                LastMessage = latestMessages.FirstOrDefault(x => x.DeviceId == device.Id)?.Latest,
-                LastMessageUtc = latestMessages.FirstOrDefault(x => x.DeviceId == device.Id)?.LatestUtc
+                LastMessage = latestMessages.FirstOrDefault(x => x.DeviceId == device.Id)?.Latest
             }).ToList();
         }
 

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -104,7 +104,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
                 TimeStamp = x.Max(d => d.TimeStamp)
             }).ToListAsync();
 
-            var latestMessages =  await _context.Measurements.Where(x => deviceIds.Contains(x.Sensor.DeviceId)).GroupBy(x => x.Sensor.DeviceId).Select(d => new { DeviceId = d.Key, Latest = d.Max(x => x.Timestamp), LatestUtc = d.Max(x => x.TimestampUtc) }).ToListAsync();
+            var latestMessages = await _context.Measurements.Where(x => deviceIds.Contains(x.Sensor.DeviceId)).GroupBy(x => x.Sensor.DeviceId).Select(d => new { DeviceId = d.Key, Latest = d.Max(x => x.Timestamp) }).ToListAsync();
 
             return devices.Select(device => new DeviceInfo()
             {


### PR DESCRIPTION
- Remove TimestampUtc from ``DeviceInfo`` and ``DeviceInfoDto``. Utc timestamp wasn't really in use and also not part of the index. 
- Added a ValueResolver, ``ShowDeviceWarningResolver``, for determining whether the device is in a warning state or not. Having done this, there is no need for the Utc timestamp and also, it is a better practice to place the logic warning state in a resolver.