### PR TITLE
Time range changes for dashboard view and refactoring

### DIFF
--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Device } from "../models/device";
+import { Sensor } from "../models/sensor";
+import { MeasurementsViewModel } from "../models/measurementsBySensor";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  getDeviceAutoScale,
+  toggleAutoScale,
+} from "../reducers/measurementReducer";
+import { Box } from "@mui/material";
+import { MultiSensorGraph } from "./MultiSensorGraph";
+
+export const DashboardDeviceGraph: React.FC<{
+  device: Device;
+  sensors: Sensor[];
+  model: MeasurementsViewModel | undefined;
+}> = ({ device, sensors, model }) => {
+  const useAutoScale = useSelector(getDeviceAutoScale(device.id));
+  const dispatch = useDispatch();
+  return (
+    <Box
+      sx={{
+        border: "1px solid #ccc",
+        borderRadius: 2,
+        padding: 1,
+        boxSizing: "border-box",
+        backgroundColor: "#f9f9f9",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <MultiSensorGraph
+        sensors={sensors}
+        devices={[device]}
+        model={model}
+        minHeight={400}
+        titleAsLink
+        useAutoScale={useAutoScale}
+        onSetAutoScale={(state) =>
+          dispatch(toggleAutoScale({ deviceId: device.id, state }))
+        }
+      />
+    </Box>
+  );
+};

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -23,6 +23,7 @@ import {
 import { Link } from "react-router";
 import { routes } from "../utilities/routes";
 import { useCallback, useEffect, useState } from "react";
+import React from "react";
 
 Chart.register(
   TimeScale,

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -23,7 +23,6 @@ import {
 import { Link } from "react-router";
 import { routes } from "../utilities/routes";
 import { useCallback, useEffect, useState } from "react";
-import React from "react";
 
 Chart.register(
   TimeScale,

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
@@ -6,7 +6,7 @@ export interface TimeRangeSelectorComponentProps {
   onSelectTimeRange: (selection: number) => void;
 }
 
-const timeOptions = [6, 12, 24, 48, 72];
+const timeRangeOptions = [6, 12, 24, 48, 72];
 
 export const TimeRangeSelectorComponent: React.FC<
   TimeRangeSelectorComponentProps
@@ -31,7 +31,7 @@ export const TimeRangeSelectorComponent: React.FC<
         {`${timeRange} h`}
       </Button>
       <Menu anchorEl={anchorEl} open={open} onClose={() => handleClose()}>
-        {timeOptions.map((option) => (
+        {timeRangeOptions.map((option) => (
           <MenuItem
             key={option}
             selected={timeRange === option}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
@@ -1,50 +1,46 @@
-import { Box, Button } from "@mui/material";
-import { TimeSelections } from "../enums/timeSelections";
+import { Box, Button, Menu, MenuItem } from "@mui/material";
+import { useState } from "react";
 
 export interface TimeRangeSelectorComponentProps {
-  timeRange: TimeSelections;
-  onSelectTimeRange: (selection: TimeSelections) => void;
+  timeRange: number;
+  onSelectTimeRange: (selection: number) => void;
 }
+
+const timeOptions = [6, 12, 24, 48, 72];
 
 export const TimeRangeSelectorComponent: React.FC<
   TimeRangeSelectorComponentProps
 > = ({ timeRange, onSelectTimeRange }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (value?: number) => {
+    if (value !== undefined) {
+      onSelectTimeRange(value);
+    }
+    setAnchorEl(null);
+  };
+
   return (
-    <Box
-      sx={{
-        display: "flex",
-        justifyContent: "start",
-        alignItems: "start",
-        gap: 2,
-      }}
-    >
-      <Button
-        size="small"
-        onClick={() => {
-          onSelectTimeRange(TimeSelections.Hour24);
-        }}
-        variant={timeRange === TimeSelections.Hour24 ? "contained" : "outlined"}
-      >
-        24 h
+    <Box>
+      <Button variant="outlined" size="small" onClick={handleClick}>
+        {`${timeRange} h`}
       </Button>
-      <Button
-        size="small"
-        variant={timeRange === TimeSelections.Hour48 ? "contained" : "outlined"}
-        onClick={() => {
-          onSelectTimeRange(TimeSelections.Hour48);
-        }}
-      >
-        48 h
-      </Button>
-      <Button
-        size="small"
-        onClick={() => {
-          onSelectTimeRange(TimeSelections.Hour72);
-        }}
-        variant={timeRange === TimeSelections.Hour72 ? "contained" : "outlined"}
-      >
-        72 h
-      </Button>
+      <Menu anchorEl={anchorEl} open={open} onClose={() => handleClose()}>
+        {timeOptions.map((option) => (
+          <MenuItem
+            key={option}
+            selected={timeRange === option}
+            onClick={() => handleClose(option)}
+          >
+            {`${option} h`}
+          </MenuItem>
+        ))}
+      </Menu>
     </Box>
   );
 };

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -2,19 +2,17 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppContentWrapper } from "../framework/AppContentWrapper";
 import React, { useEffect, useMemo, useState } from "react";
 import {
-  getDashboardAutoScale,
   getDashboardTimeRange,
   getDevices,
   getSensors,
   setDashboardTimeRange,
-  toggleAutoScale,
 } from "../reducers/measurementReducer";
 import { useApiHook } from "../hooks/apiHook";
 import { Box } from "@mui/material";
 import moment from "moment";
 import { MeasurementsViewModel } from "../models/measurementsBySensor";
-import { MultiSensorGraph } from "../components/MultiSensorGraph";
 import { TimeRangeSelectorComponent } from "../components/TimeRangeSelectorComponent";
+import { DashboardDeviceGraph } from "../components/DashboardDeviceGraph";
 
 export const DashboardView: React.FC = () => {
   const measurementApiHook = useApiHook().measureHook;
@@ -26,7 +24,6 @@ export const DashboardView: React.FC = () => {
 
   const sensors = useSelector(getSensors);
   const devices = useSelector(getDevices);
-  const autoScaleIds = useSelector(getDashboardAutoScale);
 
   const timeRange = useSelector(getDashboardTimeRange);
 
@@ -113,33 +110,12 @@ export const DashboardView: React.FC = () => {
           {memoizedMeasurements.map(
             ({ device, deviceSensors, measurementsModel }) => {
               return (
-                <Box
+                <DashboardDeviceGraph
+                  device={device}
+                  model={measurementsModel}
+                  sensors={deviceSensors}
                   key={device.id}
-                  sx={{
-                    border: "1px solid #ccc",
-                    borderRadius: 2,
-                    padding: 1,
-                    boxSizing: "border-box",
-                    backgroundColor: "#f9f9f9",
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "center",
-                    alignItems: "center",
-                  }}
-                >
-                  <MultiSensorGraph
-                    sensors={deviceSensors}
-                    devices={[device]}
-                    model={measurementsModel}
-                    minHeight={400}
-                    titleAsLink
-                    useAutoScale={autoScaleIds.includes(device.id)}
-                    onSetAutoScale={(state) => {
-                      dispatch(toggleAutoScale({ deviceId: device.id, state }));
-                    }}
-                  />
-                </Box>
+                />
               );
             }
           )}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -14,7 +14,6 @@ import { Box } from "@mui/material";
 import moment from "moment";
 import { MeasurementsViewModel } from "../models/measurementsBySensor";
 import { MultiSensorGraph } from "../components/MultiSensorGraph";
-import { TimeSelections } from "../enums/timeSelections";
 import { TimeRangeSelectorComponent } from "../components/TimeRangeSelectorComponent";
 
 export const DashboardView: React.FC = () => {
@@ -31,7 +30,7 @@ export const DashboardView: React.FC = () => {
 
   const timeRange = useSelector(getDashboardTimeRange);
 
-  const handleTimeRangeChange = (selection: TimeSelections) => {
+  const handleTimeRangeChange = (selection: number) => {
     dispatch(setDashboardTimeRange(selection));
   };
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -64,16 +64,17 @@ export const DashboardView: React.FC = () => {
       .catch((er) => {
         console.error(er);
         setViewModel(undefined);
-        setIsLoading(false);
       })
       .finally(() => {
-        // setIsLoading(false);
+        setIsLoading(false);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeRange]);
 
   useEffect(() => {
-    setIsLoading(true);
+    if (devices.length === 0) {
+      return;
+    }
     setDashboardModel(
       devices.map((device) => {
         const deviceSensors = sensors.filter((s) => s.deviceId === device.id);
@@ -92,7 +93,6 @@ export const DashboardView: React.FC = () => {
         };
       })
     );
-    setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewModel]);
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/MeasurementsView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/MeasurementsView.tsx
@@ -1,12 +1,14 @@
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { AppContentWrapper } from "../framework/AppContentWrapper";
 import React, { useEffect, useState } from "react";
 import { useApiHook } from "../hooks/apiHook";
 import { MeasurementsLeftView } from "../components/MeasurementsLeftView";
 import {
   getDashboardTimeRange,
+  getDeviceAutoScale,
   getDevices,
   getSensors,
+  toggleAutoScale,
 } from "../reducers/measurementReducer";
 import { Box } from "@mui/material";
 import { Device } from "../models/device";
@@ -18,6 +20,7 @@ import moment from "moment";
 
 export const MeasurementsView: React.FC = () => {
   const measurementApiHook = useApiHook().measureHook;
+  const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const { deviceId } = useParams<{ deviceId?: string }>();
   const [selectedDevices, setSelectedDevices] = useState<Device[]>([]);
@@ -29,10 +32,12 @@ export const MeasurementsView: React.FC = () => {
   const [timeFrom, setTimeFrom] = useState<moment.Moment | undefined>(
     undefined
   );
-
   const devices = useSelector(getDevices);
   const sensors = useSelector(getSensors);
   const dashboardTimeRange = useSelector(getDashboardTimeRange);
+  const autoScaleInUseForDevice = useSelector(
+    getDeviceAutoScale(selectedDevices.length === 1 ? selectedDevices[0].id : 0)
+  );
   const [selectedSensors, setSelectedSensors] = useState<Sensor[]>([]);
 
   const toggleSensorSelection = (sensorId: number) => {
@@ -164,6 +169,19 @@ export const MeasurementsView: React.FC = () => {
           devices={selectedDevices}
           key={"graph_01"}
           minHeight={500}
+          useAutoScale={
+            selectedDevices.length === 1 ? autoScaleInUseForDevice : undefined
+          }
+          onSetAutoScale={(state) => {
+            if (selectedDevices.length === 1) {
+              dispatch(
+                toggleAutoScale({
+                  deviceId: selectedDevices[0].id,
+                  state: state,
+                })
+              );
+            }
+          }}
         />
       </Box>
     </AppContentWrapper>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/enums/timeSelections.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/enums/timeSelections.ts
@@ -1,5 +1,0 @@
-export enum TimeSelections {
-  Hour24 = 24,
-  Hour48 = 48,
-  Hour72 = 72,
-}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/reducers/measurementReducer.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/reducers/measurementReducer.ts
@@ -1,4 +1,3 @@
-import { TimeSelections } from "./../enums/timeSelections";
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { Device } from "../models/device";
@@ -9,7 +8,7 @@ export interface MeasurementState {
   devices: Device[];
   sensors: Sensor[];
   autoScaleSensorIds: number[];
-  timeRange: TimeSelections;
+  timeRange: number;
 }
 
 export interface DashboardAutoScale {
@@ -21,7 +20,7 @@ const initialState: MeasurementState = {
   devices: [],
   sensors: [],
   autoScaleSensorIds: [],
-  timeRange: TimeSelections.Hour24,
+  timeRange: 24,
 };
 
 export const measurementSlice = createSlice({
@@ -47,7 +46,7 @@ export const measurementSlice = createSlice({
         );
       }
     },
-    setDashboardTimeRange: (state, action: PayloadAction<TimeSelections>) => {
+    setDashboardTimeRange: (state, action: PayloadAction<number>) => {
       state.timeRange = action.payload;
     },
   },
@@ -70,7 +69,7 @@ export const getDashboardAutoScale = (state: RootState): number[] => {
   return state.measurementInfo.autoScaleSensorIds;
 };
 
-export const getDashboardTimeRange = (state: RootState): TimeSelections => {
+export const getDashboardTimeRange = (state: RootState): number => {
   return state.measurementInfo.timeRange;
 };
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/reducers/measurementReducer.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/reducers/measurementReducer.ts
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { Device } from "../models/device";
 import { Sensor } from "../models/sensor";
@@ -68,6 +68,12 @@ export const getSensors = (state: RootState): Sensor[] =>
 export const getDashboardAutoScale = (state: RootState): number[] => {
   return state.measurementInfo.autoScaleSensorIds;
 };
+
+export const getDeviceAutoScale = (deviceId: number) =>
+  createSelector(
+    [(state: RootState) => state.measurementInfo.autoScaleSensorIds],
+    (autoScaleSensorIds) => autoScaleSensorIds.includes(deviceId)
+  );
 
 export const getDashboardTimeRange = (state: RootState): number => {
   return state.measurementInfo.timeRange;


### PR DESCRIPTION
- Instead of buttons, use a list of options in DashBoad when selecting time range. The following options are available:
  - 6 h
  - 12 h
  - 24 h
  - 48 h
  - 72 h
- Created  a wrapper component for a device in dashboard.
- Store and retrieve ``useAutoScale`` using reducer in ``MeasurementsView`` if a single device is chosen
- use ``useMemo`` instead of state for storing measurements view model in DashboardView and MultiSensorGraph
 