### PR TITLE
Add functionality for refreshing a single device graph in dashboard

### DIFF
--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -240,7 +240,12 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
           }}
         />
         {onRefresh && (
-          <Button variant="contained" onClick={onRefresh} size="small">
+          <Button
+            variant="outlined"
+            onClick={onRefresh}
+            size="small"
+            sx={{ marginLeft: "auto" }}
+          >
             Refresh
           </Button>
         )}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -1,7 +1,13 @@
 import "chartjs-adapter-moment";
 import { MeasurementTypes } from "../enums/measurementTypes";
 import { Sensor } from "../models/sensor";
-import { Box, Checkbox, FormControlLabel, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Typography,
+} from "@mui/material";
 import { MeasurementsViewModel } from "../models/measurementsBySensor";
 import { Device } from "../models/device";
 import {
@@ -43,6 +49,7 @@ export interface MultiSensorGraphProps {
   titleAsLink?: boolean;
   useAutoScale?: boolean;
   onSetAutoScale?: (state: boolean) => void;
+  onRefresh?: () => void;
 }
 
 interface GraphDataset {
@@ -65,6 +72,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   titleAsLink,
   useAutoScale,
   onSetAutoScale,
+  onRefresh,
 }) => {
   const singleDevice = devices && devices.length === 1 ? devices[0] : undefined;
 
@@ -231,6 +239,11 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
             typography: { fontSize: "14px" }, // Adjust font size
           }}
         />
+        {onRefresh && (
+          <Button variant="contained" onClick={onRefresh} size="small">
+            Refresh
+          </Button>
+        )}
       </Box>
       <Box
         flex={1}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -121,6 +121,7 @@ export const DashboardView: React.FC = () => {
                 model={model}
                 sensors={sensors}
                 key={device.id}
+                timeRange={timeRange}
               />
             );
           })}


### PR DESCRIPTION
- ``MultiSensorGraph`` now supports onRefresh function prop.
- Added functionality for refreshing a single device graph in dashboard. Functionality was added to ``DashboardDeviceGraph``. In there, it is now possible to fetch measurement data for sensors of the device and update it to graph. In case measurement model given as props changes, it will be shown.
- Refresh-functionality also taken into use in ``MeasurementsView``
