### PR TITLE
Functionality for changing and showing device default image

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
@@ -12,7 +12,8 @@ namespace EnvironmentMonitor.Application.DTOs
     public class DeviceAttachmentDto : IMapFrom<DeviceAttachment>
     {
         public Guid Guid { get; set; }
-        public bool IsImage { get; set; } = true;
+        public bool IsImage { get; set; }
+        public bool IsDefaultImage { get; set; }
 
         public void Mapping(Profile profile)
         {

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
@@ -15,10 +15,11 @@ namespace EnvironmentMonitor.Application.DTOs
         public bool IsImage { get; set; }
         public bool IsDefaultImage { get; set; }
         public DateTime Created { get; set; }
+        public string? Name { get; set; }
 
         public void Mapping(Profile profile)
         {
-            profile.CreateMap<DeviceAttachment, DeviceAttachmentDto>().ReverseMap();
+            profile.CreateMap<DeviceAttachment, DeviceAttachmentDto>().ForMember(x => x.Name, opt => opt.MapFrom(x => x.Attachment != null ? x.Attachment.OriginalName : "")).ReverseMap();
         }
     }
 }

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceAttachmentDto.cs
@@ -14,6 +14,7 @@ namespace EnvironmentMonitor.Application.DTOs
         public Guid Guid { get; set; }
         public bool IsImage { get; set; }
         public bool IsDefaultImage { get; set; }
+        public DateTime Created { get; set; }
 
         public void Mapping(Profile profile)
         {

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
@@ -13,13 +13,15 @@ namespace EnvironmentMonitor.Application.DTOs
         public DateTime? RebootedOn { get; set; }
         public DateTime? LastMessage { get; set; }
         public List<DeviceAttachmentDto> Attachments { get; set; } = [];
+        public Guid? DefaultImageGuid { get; set; }
 
         public bool ShowWarning { get; set; }
         public void Mapping(Profile profile)
         {
             profile.CreateMap<DeviceInfo, DeviceInfoDto>()
                 .ForMember(x => x.ShowWarning, opt => opt.MapFrom<ShowDeviceWarningResolver>())
-                .ForMember(x => x.Attachments, opt => opt.MapFrom(x => x.Device.Attachments ?? new List<DeviceAttachment>())).ReverseMap(); // Check
+                .ForMember(x => x.Attachments, opt => opt.MapFrom(x => x.Device.Attachments ?? new List<DeviceAttachment>()))
+                .ReverseMap();
         }
     }
 }

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -25,6 +25,8 @@ namespace EnvironmentMonitor.Application.Interfaces
         public Task AddAttachment(string deviceIdentifier, UploadAttachmentModel fileModel);
         public Task DeleteAttachment(string deviceIdentifier, Guid attachmentIdentifier);
         public Task<AttachmentInfoModel?> GetAttachment(string deviceIdentifier, Guid attachmentIdentifier);
+        public Task<AttachmentInfoModel?> GetDefaultImage(string deviceIdentifier);
+        public Task SetDefaultImage(string deviceIdentifier, Guid attachmentGuid);
 
         public Task<List<DeviceEventDto>> GetDeviceEvents(string identifier);
 

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -212,5 +212,23 @@ namespace EnvironmentMonitor.Application.Services
             var attachment = await _deviceRepository.GetAttachment(device.Id, attachmentIdentifier);
             return await _storageClient.GetImageAsync(attachment.Name);
         }
+        public async Task<AttachmentInfoModel?> GetDefaultImage(string deviceIdentifier)
+        {
+            var device = await GetDevice(deviceIdentifier, AccessLevels.Read);
+            var deviceInfo = (await _deviceRepository.GetDeviceInfo([device.Id], false, true)).FirstOrDefault();
+            var attachment = deviceInfo?.Device.Attachments.FirstOrDefault(x => x.IsDefaultImage);
+            if (attachment == null)
+            {
+                return null;
+            }
+            return await _storageClient.GetImageAsync(attachment.Attachment.Name);
+        }
+
+        public async Task SetDefaultImage(string deviceIdentifier, Guid attachmentGuid)
+        {
+            _logger.LogInformation($"Setting default image for device '{deviceIdentifier}'");
+            var device = await GetDevice(deviceIdentifier, AccessLevels.Write);
+            await _deviceRepository.SetDefaultImage(device.Id, attachmentGuid);
+        }
     }
 }

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -32,6 +32,7 @@ namespace EnvironmentMonitor.Domain.Interfaces
         public Task<DeviceEvent> AddEvent(int deviceId, DeviceEventTypes type, string message, bool saveChanges, DateTime? datetimeUtc);
         public Task AddAttachment(int deviceId, Attachment attachment, bool saveChanges);
         public Task DeleteAttachment(int deviceId, Guid attachmentIdentifier, bool saveChanges);
+        public Task SetDefaultImage(int deviceId, Guid attachmentIdentifier);
         public Task SaveChanges();
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/DeviceInfo.cs
+++ b/src/EnvironmentMonitor.Domain/Models/DeviceInfo.cs
@@ -8,5 +8,6 @@ namespace EnvironmentMonitor.Domain.Models
         public DateTime? OnlineSince { get; set; }
         public DateTime? RebootedOn { get; set; }
         public DateTime? LastMessage { get; set; }
+        public Guid? DefaultImageGuid { get; set; }
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
@@ -20,4 +20,9 @@ namespace EnvironmentMonitor.Domain.Models
     {
         public long DelayMs { get; set; }
     }
+
+    public class SetDefaultImage: MessageDeviceModel
+    {
+        public Guid AttachmentGuid { get; set; }
+    }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -55,7 +55,7 @@ namespace EnvironmentMonitor.Infrastructure.Extensions
             services.AddSingleton(storageAccountSettings);
 
             var fileUploadDefaultSettings = new FileUploadSettings();
-            configuration.GetSection("FileUploadSettings").Bind(defaultSettings);
+            configuration.GetSection("FileUploadSettings").Bind(fileUploadDefaultSettings);
             services.AddSingleton(fileUploadDefaultSettings);
 
             services.AddSingleton<IDateService, DateService>();

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/CollabsibleComponent.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/CollabsibleComponent.tsx
@@ -34,8 +34,8 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
   };
 
   return (
-    <Box sx={{ mb: 2, mt: 2 }}>
-      <Box display="flex" alignItems="center" sx={{ mb: 2 }}>
+    <Box sx={{ mb: 1, mt: 1 }}>
+      <Box display="flex" alignItems="center" sx={{ mb: 1 }}>
         <Box sx={{ display: "flex", flexDirection: "row" }}>
           <ExpandMoreIconButton
             expand={open ? 1 : 0}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -2,6 +2,9 @@ import {
   Box,
   Button,
   CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   IconButton,
   Tooltip,
   Typography,
@@ -11,8 +14,10 @@ import {
   ArrowBack,
   ArrowForward,
   CheckCircle,
+  Close,
   Delete,
   FileUpload,
+  WidthFull,
 } from "@mui/icons-material";
 import { DeviceInfo } from "../models/deviceInfo";
 import { Collapsible } from "./CollabsibleComponent";
@@ -40,6 +45,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
   const [isLoadingImage, setIsLoadingImage] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string>("");
 
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: (files) => {
@@ -121,6 +127,52 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
         </Tooltip>
       }
     >
+      <Dialog
+        open={imagePreviewUrl.length > 0}
+        onClose={() => {
+          setImagePreviewUrl("");
+        }}
+        maxWidth="xl"
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+        >
+          <Box
+            sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
+          ></Box>
+          <Box sx={{ display: "flex", flexBasis: "row" }}>
+            <IconButton
+              aria-label="close"
+              onClick={() => {
+                setImagePreviewUrl("");
+              }}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+              size="small"
+            >
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Box
+            component="img"
+            src={`${imagePreviewUrl}`}
+            alt="Preview"
+            sx={{
+              width: "100%",
+              height: "auto",
+              borderRadius: 1,
+              display: "block",
+            }}
+          />
+        </DialogContent>
+      </Dialog>
       <Box
         marginTop={2}
         display={"flex"}
@@ -221,6 +273,17 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                     size="small"
                   >
                     <CheckCircle />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={"Expand"}>
+                  <IconButton
+                    onClick={() => {
+                      setImagePreviewUrl(urls[currentIndex].url);
+                    }}
+                    sx={{ ml: 1, cursor: "pointer" }}
+                    size="small"
+                  >
+                    <WidthFull />
                   </IconButton>
                 </Tooltip>
               </Box>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -18,6 +18,7 @@ import { DeviceInfo } from "../models/deviceInfo";
 import { Collapsible } from "./CollabsibleComponent";
 import { useSwipeable } from "react-swipeable";
 import { useDropzone } from "react-dropzone";
+import { stringSort } from "../utilities/stringUtils";
 
 export interface DeviceImageProps {
   device: DeviceInfo | undefined;
@@ -84,15 +85,18 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
     fileInputRef.current?.click();
   };
 
-  const urls =
-    device?.attachments.map((s) => {
-      return {
-        url: `/api/devices/attachment/${device?.device.deviceIdentifier}/${s.guid}`,
-        guid: s.guid,
-      };
-    }) ?? [];
+  const urls = device?.attachments
+    ? device?.attachments
+        .sort((a, b) => stringSort(a.guid, b.guid))
+        .map((s) => {
+          return {
+            url: `/api/devices/attachment/${device?.device.deviceIdentifier}/${s.guid}`,
+            guid: s.guid,
+          };
+        })
+    : [];
 
-  const isDisabled = (guid: string) => {
+  const isDefaultImage = (guid: string) => {
     return (
       device === undefined ||
       (device.defaultImageGuid.length > 0 && device.defaultImageGuid === guid)
@@ -212,7 +216,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                       const attachment = device.attachments[currentIndex];
                       onSetDefaultImage(attachment.guid);
                     }}
-                    disabled={isDisabled(urls[currentIndex].guid)}
+                    disabled={isDefaultImage(urls[currentIndex].guid)}
                     sx={{ ml: 1, cursor: "pointer" }}
                     size="small"
                   >

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -2,9 +2,6 @@ import {
   Box,
   Button,
   CircularProgress,
-  Dialog,
-  DialogContent,
-  DialogTitle,
   IconButton,
   Tooltip,
   Typography,
@@ -14,7 +11,6 @@ import {
   ArrowBack,
   ArrowForward,
   CheckCircle,
-  Close,
   Delete,
   FileUpload,
   WidthFull,
@@ -24,6 +20,7 @@ import { Collapsible } from "./CollabsibleComponent";
 import { useSwipeable } from "react-swipeable";
 import { useDropzone } from "react-dropzone";
 import { stringSort } from "../utilities/stringUtils";
+import { DeviceImageDialog } from "./DeviceImageDialog";
 
 export interface DeviceImageProps {
   device: DeviceInfo | undefined;
@@ -127,52 +124,13 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
         </Tooltip>
       }
     >
-      <Dialog
-        open={imagePreviewUrl.length > 0}
+      <DeviceImageDialog
+        isOpen={imagePreviewUrl.length > 0}
+        imageUrl={imagePreviewUrl}
         onClose={() => {
           setImagePreviewUrl("");
         }}
-        maxWidth="xl"
-      >
-        <DialogTitle
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <Box
-            sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
-          ></Box>
-          <Box sx={{ display: "flex", flexBasis: "row" }}>
-            <IconButton
-              aria-label="close"
-              onClick={() => {
-                setImagePreviewUrl("");
-              }}
-              sx={{
-                color: (theme) => theme.palette.grey[500],
-              }}
-              size="small"
-            >
-              <Close />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent>
-          <Box
-            component="img"
-            src={`${imagePreviewUrl}`}
-            alt="Preview"
-            sx={{
-              width: "100%",
-              height: "auto",
-              borderRadius: 1,
-              display: "block",
-            }}
-          />
-        </DialogContent>
-      </Dialog>
+      />
       <Box
         marginTop={2}
         display={"flex"}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -55,18 +55,20 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
   });
 
   const prevImage = () => {
-    if (urls.length <= 1) {
+    if (attachments.length <= 1) {
       return;
     }
-    setCurrentIndex((prev) => (prev - 1 + urls.length) % urls.length);
+    setCurrentIndex(
+      (prev) => (prev - 1 + attachments.length) % attachments.length
+    );
     setIsLoadingImage(true);
   };
 
   const nextImage = () => {
-    if (urls.length <= 1) {
+    if (attachments.length <= 1) {
       return;
     }
-    setCurrentIndex((prev) => (prev + 1) % urls.length);
+    setCurrentIndex((prev) => (prev + 1) % attachments.length);
     setIsLoadingImage(true);
   };
 
@@ -88,14 +90,12 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
     fileInputRef.current?.click();
   };
 
-  const urls = device?.attachments
+  const attachments = device?.attachments
     ? device?.attachments.sort((a, b) => dateTimeSort(b.created, a.created))
     : [];
 
   const activeAttachment =
-    device && device.attachments.length >= currentIndex
-      ? device.attachments[currentIndex]
-      : undefined;
+    attachments.length > currentIndex ? attachments[currentIndex] : undefined;
 
   const isDefaultImage = () => {
     if (device === undefined || activeAttachment === undefined) {
@@ -144,7 +144,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
         {...getRootProps()}
       >
         <input {...getInputProps()} />
-        {urls !== undefined && urls.length > 0 ? (
+        {attachments !== undefined && attachments.length > 0 ? (
           <Box
             sx={{
               position: "relative",
@@ -227,7 +227,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
               >
                 <Typography variant="caption" textAlign={"center"}>{` ${
                   currentIndex + 1
-                }/${urls.length}`}</Typography>
+                }/${attachments.length}`}</Typography>
                 <Tooltip title={"Delete image?"}>
                   <IconButton
                     onClick={() => {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -193,8 +193,14 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                 Added:
               </Typography>
               <Typography variant="body2">
-                {getFormattedDate(urls[currentIndex]?.created)}
+                {activeAttachment !== undefined
+                  ? getFormattedDate(activeAttachment?.created)
+                  : "-"}
               </Typography>
+              <Typography variant="body2" fontWeight="bold" ml={1} mr={1}>
+                Name:
+              </Typography>
+              <Typography variant="body2">{activeAttachment?.name}</Typography>
             </Box>
             <Box
               sx={{

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -19,8 +19,8 @@ import { DeviceInfo } from "../models/deviceInfo";
 import { Collapsible } from "./CollabsibleComponent";
 import { useSwipeable } from "react-swipeable";
 import { useDropzone } from "react-dropzone";
-import { stringSort } from "../utilities/stringUtils";
 import { DeviceImageDialog } from "./DeviceImageDialog";
+import { dateTimeSort } from "../utilities/datetimeUtils";
 
 export interface DeviceImageProps {
   device: DeviceInfo | undefined;
@@ -90,7 +90,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
 
   const urls = device?.attachments
     ? device?.attachments
-        .sort((a, b) => stringSort(a.guid, b.guid))
+        .sort((a, b) => dateTimeSort(b.created, a.created))
         .map((s) => {
           return {
             url: `/api/devices/attachment/${device?.device.deviceIdentifier}/${s.guid}`,
@@ -141,7 +141,6 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
         {urls !== undefined && urls.length > 0 ? (
           <Box
             sx={{
-              maxHeight: 600,
               position: "relative",
 
               display: "flex",
@@ -173,7 +172,8 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                 width: "100%",
                 display: "block",
                 height: "auto",
-                maxHeight: 500,
+                minHeight: "300px",
+                maxHeight: "min(80vh, 600px)",
                 objectFit: "contain",
                 filter: isLoadingImage ? "blur(10px)" : "none",
                 transition: "filter 0.3s ease-in-out",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -96,14 +96,15 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
     device && device.attachments.length >= currentIndex
       ? device.attachments[currentIndex]
       : undefined;
-  const isDefaultImage = (guid: string) => {
-    return (
-      device === undefined ||
-      (device.defaultImageGuid.length > 0 && device.defaultImageGuid === guid)
-    );
+
+  const isDefaultImage = () => {
+    if (device === undefined || activeAttachment === undefined) {
+      return false;
+    }
+    return device.defaultImageGuid === activeAttachment.guid;
   };
 
-  const getCurrentAttachment = () => {
+  const getCurrentAttachmentUrl = () => {
     if (!activeAttachment) {
       return "";
     }
@@ -171,7 +172,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
               </Box>
             )}
             <img
-              src={getCurrentAttachment()}
+              src={getCurrentAttachmentUrl()}
               alt="Device"
               style={{
                 width: "100%",
@@ -249,10 +250,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                       }
                       onSetDefaultImage(activeAttachment.guid);
                     }}
-                    disabled={
-                      activeAttachment === undefined ||
-                      isDefaultImage(activeAttachment.guid)
-                    }
+                    disabled={isDefaultImage()}
                     sx={{ ml: 1, cursor: "pointer" }}
                     size="small"
                   >
@@ -262,7 +260,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
                 <Tooltip title={"Expand"}>
                   <IconButton
                     onClick={() => {
-                      setImagePreviewUrl(getCurrentAttachment());
+                      setImagePreviewUrl(getCurrentAttachmentUrl());
                     }}
                     sx={{ ml: 1, cursor: "pointer" }}
                     size="small"

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
@@ -5,8 +5,6 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
 
 export interface DeviceImageDialogProps {
@@ -22,36 +20,31 @@ export const DeviceImageDialog: React.FC<DeviceImageDialogProps> = ({
   isOpen,
   onClose,
 }) => {
-  const theme = useTheme();
-  const drawTitle = useMediaQuery(theme.breakpoints.up("lg"));
-
   return (
     <Dialog open={isOpen} onClose={onClose} maxWidth="xl">
-      {drawTitle && (
-        <DialogTitle
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <Box>{title ?? ""}</Box>
-          <Box sx={{ display: "flex", flexBasis: "row" }}>
-            <IconButton
-              aria-label="close"
-              onClick={() => {
-                onClose();
-              }}
-              sx={{
-                color: (theme) => theme.palette.grey[500],
-              }}
-              size="small"
-            >
-              <Close />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-      )}
+      <DialogTitle
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        <Box>{title ?? ""}</Box>
+        <Box sx={{ display: "flex", flexBasis: "row" }}>
+          <IconButton
+            aria-label="close"
+            onClick={() => {
+              onClose();
+            }}
+            sx={{
+              color: (theme) => theme.palette.grey[500],
+            }}
+            size="small"
+          >
+            <Close />
+          </IconButton>
+        </Box>
+      </DialogTitle>
 
       <DialogContent>
         <Box
@@ -59,10 +52,10 @@ export const DeviceImageDialog: React.FC<DeviceImageDialogProps> = ({
           src={imageUrl}
           alt="Preview"
           sx={{
-            width: "100%",
-            height: "auto",
-            borderRadius: 1,
-            display: "block",
+              width: "100%",
+              height: "auto",
+              borderRadius: 1,
+              display: "block"
           }}
         />
       </DialogContent>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
@@ -1,0 +1,63 @@
+import { Close } from "@mui/icons-material";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+} from "@mui/material";
+
+export interface DeviceImageDialogProps {
+  title?: string;
+  isOpen: boolean;
+  imageUrl: string;
+  onClose: () => void;
+}
+
+export const DeviceImageDialog: React.FC<DeviceImageDialogProps> = ({
+  imageUrl,
+  title,
+  isOpen,
+  onClose,
+}) => {
+  return (
+    <Dialog open={isOpen} onClose={onClose} maxWidth="xl">
+      <DialogTitle
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        <Box>{title ?? ""}</Box>
+        <Box sx={{ display: "flex", flexBasis: "row" }}>
+          <IconButton
+            aria-label="close"
+            onClick={() => {
+              onClose();
+            }}
+            sx={{
+              color: (theme) => theme.palette.grey[500],
+            }}
+            size="small"
+          >
+            <Close />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box
+          component="img"
+          src={imageUrl}
+          alt="Preview"
+          sx={{
+            width: "100%",
+            height: "auto",
+            borderRadius: 1,
+            display: "block",
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImageDialog.tsx
@@ -5,6 +5,8 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 
 export interface DeviceImageDialogProps {
@@ -20,31 +22,37 @@ export const DeviceImageDialog: React.FC<DeviceImageDialogProps> = ({
   isOpen,
   onClose,
 }) => {
+  const theme = useTheme();
+  const drawTitle = useMediaQuery(theme.breakpoints.up("lg"));
+
   return (
     <Dialog open={isOpen} onClose={onClose} maxWidth="xl">
-      <DialogTitle
-        sx={{
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "space-between",
-        }}
-      >
-        <Box>{title ?? ""}</Box>
-        <Box sx={{ display: "flex", flexBasis: "row" }}>
-          <IconButton
-            aria-label="close"
-            onClick={() => {
-              onClose();
-            }}
-            sx={{
-              color: (theme) => theme.palette.grey[500],
-            }}
-            size="small"
-          >
-            <Close />
-          </IconButton>
-        </Box>
-      </DialogTitle>
+      {drawTitle && (
+        <DialogTitle
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+        >
+          <Box>{title ?? ""}</Box>
+          <Box sx={{ display: "flex", flexBasis: "row" }}>
+            <IconButton
+              aria-label="close"
+              onClick={() => {
+                onClose();
+              }}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+              size="small"
+            >
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+      )}
+
       <DialogContent>
         <Box
           component="img"

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -1,20 +1,12 @@
 import { DeviceInfo } from "../models/deviceInfo";
-import {
-  Box,
-  Checkbox,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Box, Checkbox, IconButton, Tooltip, Typography } from "@mui/material";
 import { routes } from "../utilities/routes";
 import { Link } from "react-router";
 import { getFormattedDate } from "../utilities/datetimeUtils";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { CheckCircle, Close, Photo, WarningAmber } from "@mui/icons-material";
+import { CheckCircle, Photo, WarningAmber } from "@mui/icons-material";
 import { useState } from "react";
+import { DeviceImageDialog } from "./DeviceImageDialog";
 
 export interface DeviceTableProps {
   devices: DeviceInfo[];
@@ -215,63 +207,17 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           {title}
         </Typography>
       ) : null}
-      <Dialog
-        open={
+      <DeviceImageDialog
+        isOpen={
           selectedDeviceIdentifier !== undefined &&
           selectedDeviceIdentifier.length > 0
         }
+        imageUrl={`/api/Devices/default-image/${selectedDeviceIdentifier}`}
         onClose={() => {
           setSelectedDeviceIdentifier("");
         }}
-        maxWidth="lg"
-      >
-        <DialogTitle
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <Box
-            sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
-          >
-            {`${selectedDevice?.device.name}`}
-          </Box>
-          <Box sx={{ display: "flex", flexBasis: "row" }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mr: 2 }}>
-              {selectedDevice?.showWarning ? (
-                <WarningAmber color="warning" />
-              ) : (
-                <CheckCircle color="success" />
-              )}
-              <span>{formatDate(selectedDevice?.lastMessage)}</span>
-            </Box>
-            <IconButton
-              aria-label="close"
-              onClick={() => setSelectedDeviceIdentifier("")}
-              sx={{
-                color: (theme) => theme.palette.grey[500],
-              }}
-              size="small"
-            >
-              <Close />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent>
-          <Box
-            component="img"
-            src={`/api/Devices/default-image/${selectedDeviceIdentifier}`}
-            alt="Preview"
-            sx={{
-              width: "100%",
-              height: "auto",
-              borderRadius: 1,
-              display: "block",
-            }}
-          />
-        </DialogContent>
-      </Dialog>
+        title={selectedDevice?.device.name}
+      />
       <Box sx={{ overflow: "auto" }}>
         <DataGrid
           rows={devices}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -200,7 +200,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       : undefined;
 
   return (
-    <Box marginTop={2} display={"flex"} flexDirection={"column"}>
+    <Box marginTop={1} display={"flex"} flexDirection={"column"}>
       {title !== undefined ? (
         <Typography variant="h6" marginBottom={2}>
           {title}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -73,8 +73,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
                 src={imageUrl}
                 alt="Preview"
                 sx={{
-                  width: 600,
-                  height: "auto",
+                  maxHeight: 400,
                   transition: "filter 0.3s ease-in-out",
                   borderRadius: 1,
                   display: "block",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -1,10 +1,20 @@
 import { DeviceInfo } from "../models/deviceInfo";
-import { Box, Checkbox, IconButton, Tooltip, Typography } from "@mui/material";
+import {
+  Box,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { routes } from "../utilities/routes";
 import { Link } from "react-router";
 import { getFormattedDate } from "../utilities/datetimeUtils";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { CheckCircle, Photo, WarningAmber } from "@mui/icons-material";
+import { CheckCircle, Close, Photo, WarningAmber } from "@mui/icons-material";
+import { useState } from "react";
 
 export interface DeviceTableProps {
   devices: DeviceInfo[];
@@ -84,7 +94,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           >
             <IconButton
               onClick={() => {
-                //
+                setSelectedDeviceIdentifier(device.device.deviceIdentifier);
               }}
             >
               <Photo />
@@ -187,6 +197,17 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
     },
   ];
 
+  const [selectedDeviceIdentifier, setSelectedDeviceIdentifier] = useState<
+    string | undefined
+  >(undefined);
+
+  const selectedDevice =
+    selectedDeviceIdentifier !== undefined
+      ? devices.find(
+          (d) => d.device.deviceIdentifier === selectedDeviceIdentifier
+        )
+      : undefined;
+
   return (
     <Box marginTop={2} display={"flex"} flexDirection={"column"}>
       {title !== undefined ? (
@@ -194,6 +215,63 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           {title}
         </Typography>
       ) : null}
+      <Dialog
+        open={
+          selectedDeviceIdentifier !== undefined &&
+          selectedDeviceIdentifier.length > 0
+        }
+        onClose={() => {
+          setSelectedDeviceIdentifier("");
+        }}
+        maxWidth="lg"
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+        >
+          <Box
+            sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
+          >
+            {`${selectedDevice?.device.name}`}
+          </Box>
+          <Box sx={{ display: "flex", flexBasis: "row" }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mr: 2 }}>
+              {selectedDevice?.showWarning ? (
+                <WarningAmber color="warning" />
+              ) : (
+                <CheckCircle color="success" />
+              )}
+              <span>{formatDate(selectedDevice?.lastMessage)}</span>
+            </Box>
+            <IconButton
+              aria-label="close"
+              onClick={() => setSelectedDeviceIdentifier("")}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+              size="small"
+            >
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Box
+            component="img"
+            src={`/api/Devices/default-image/${selectedDeviceIdentifier}`}
+            alt="Preview"
+            sx={{
+              width: "100%",
+              height: "auto",
+              borderRadius: 1,
+              display: "block",
+            }}
+          />
+        </DialogContent>
+      </Dialog>
       <Box sx={{ overflow: "auto" }}>
         <DataGrid
           rows={devices}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -1,10 +1,10 @@
 import { DeviceInfo } from "../models/deviceInfo";
-import { Box, Checkbox, Typography } from "@mui/material";
+import { Box, Checkbox, IconButton, Tooltip, Typography } from "@mui/material";
 import { routes } from "../utilities/routes";
 import { Link } from "react-router";
 import { getFormattedDate } from "../utilities/datetimeUtils";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { CheckCircle, WarningAmber } from "@mui/icons-material";
+import { CheckCircle, Photo, WarningAmber } from "@mui/icons-material";
 
 export interface DeviceTableProps {
   devices: DeviceInfo[];
@@ -48,6 +48,49 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           return "";
         }
         return (row as DeviceInfo)?.device.name;
+      },
+    },
+    {
+      field: "image",
+      headerName: "Image",
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => {
+        const device = params.row as DeviceInfo;
+
+        if (!device.defaultImageGuid) {
+          return null;
+        }
+        const imageUrl = `/api/Devices/default-image/${device.device.deviceIdentifier}`;
+
+        return (
+          <Tooltip
+            title={
+              <Box
+                component="img"
+                src={imageUrl}
+                alt="Preview"
+                sx={{
+                  width: 600,
+                  height: "auto",
+                  transition: "filter 0.3s ease-in-out",
+                  borderRadius: 1,
+                  display: "block",
+                }}
+              />
+            }
+            followCursor
+            arrow
+          >
+            <IconButton
+              onClick={() => {
+                //
+              }}
+            >
+              <Photo />
+            </IconButton>
+          </Tooltip>
+        );
       },
     },
     {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -13,6 +13,7 @@ export interface DeviceTableProps {
   onReboot?: (device: DeviceInfo) => void;
   title?: string;
   disableSort?: boolean;
+  showDeviceImageAsTooltip?: boolean;
   hideName?: boolean;
 }
 
@@ -21,6 +22,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
   title,
   disableSort,
   hideName,
+  showDeviceImageAsTooltip,
 }) => {
   const formatDate = (input: Date | undefined | null) => {
     if (input) {
@@ -64,8 +66,17 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           return null;
         }
         const imageUrl = `/api/Devices/default-image/${device.device.deviceIdentifier}`;
+        const iconButtonToRender = (
+          <IconButton
+            onClick={() => {
+              setSelectedDeviceIdentifier(device.device.deviceIdentifier);
+            }}
+          >
+            <Photo />
+          </IconButton>
+        );
 
-        return (
+        return showDeviceImageAsTooltip ? (
           <Tooltip
             title={
               <Box
@@ -83,14 +94,10 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
             followCursor
             arrow
           >
-            <IconButton
-              onClick={() => {
-                setSelectedDeviceIdentifier(device.device.deviceIdentifier);
-              }}
-            >
-              <Photo />
-            </IconButton>
+            {iconButtonToRender}
           </Tooltip>
+        ) : (
+          iconButtonToRender
         );
       },
     },

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/SensorTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/SensorTable.tsx
@@ -18,7 +18,7 @@ export interface SensorTableProps {
 
 export const SensorTable: React.FC<SensorTableProps> = ({ title, sensors }) => {
   return (
-    <Box marginTop={2}>
+    <Box marginTop={1}>
       {title && (
         <Typography variant="h6" marginBottom={2}>
           {title}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -321,6 +321,31 @@ export const DeviceView: React.FC = () => {
       });
   };
 
+  const setDefaultImage = (identifier: string) => {
+    if (!selectedDevice) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    deviceHook
+      .setDefaultImage(selectedDevice?.device.deviceIdentifier, identifier)
+      .then((res) => {
+        setSelectedDevice(res);
+        dispatch(
+          addNotification({
+            title: "Default image set",
+            body: "Success",
+            severity: "success",
+          })
+        );
+      })
+      .catch((ex) => {})
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
   return (
     <AppContentWrapper
       title={`${selectedDevice?.device?.name ?? ""}`}
@@ -344,6 +369,17 @@ export const DeviceView: React.FC = () => {
           device={selectedDevice}
           ver={defaultImageVer}
           title={"Device images"}
+          onSetDefaultImage={(identifier: string) => {
+            dispatch(
+              setConfirmDialog({
+                onConfirm: () => {
+                  setDefaultImage(identifier);
+                },
+                title: "Set default image",
+                body: `Current image will be set as default image for ${selectedDevice?.device.name}`,
+              })
+            );
+          }}
           onDeleteImage={(identifier: string) => {
             dispatch(
               setConfirmDialog({

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
@@ -79,6 +79,10 @@ interface deviceHook {
     deviceIdentifier: string,
     attachmentIdentifier: string
   ) => Promise<DeviceInfo | undefined>;
+  setDefaultImage: (
+    deviceIdentifier: string,
+    attachmentIdentifier: string
+  ) => Promise<DeviceInfo | undefined>;
 }
 
 const apiClient = axios.create({
@@ -353,11 +357,29 @@ export const useApiHook = (): ApiHook => {
       ) => {
         try {
           let res = await apiClient.delete<any, AxiosResponse<DeviceInfo>>(
-            `/api/devices/attachment/${deviceIdentifier}/${attachmentIdentifier}`
+            `/api/devices/attachment/${deviceIdentifier}`
           );
           return res.data;
         } catch (Ex) {
           showError("Deleting attachment failed");
+          throw Ex;
+        }
+      },
+      setDefaultImage: async (
+        deviceIdentifier: string,
+        attachmentIdentifier: string
+      ) => {
+        try {
+          let res = await apiClient.post<any, AxiosResponse<DeviceInfo>>(
+            `/api/devices/default-image`,
+            {
+              attachmentGuid: attachmentIdentifier,
+              deviceIdentifier: deviceIdentifier,
+            }
+          );
+          return res.data;
+        } catch (Ex) {
+          showError("Setting default attachment failed");
           throw Ex;
         }
       },

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
@@ -357,7 +357,7 @@ export const useApiHook = (): ApiHook => {
       ) => {
         try {
           let res = await apiClient.delete<any, AxiosResponse<DeviceInfo>>(
-            `/api/devices/attachment/${deviceIdentifier}`
+            `/api/devices/attachment/${deviceIdentifier}/${attachmentIdentifier}`
           );
           return res.data;
         } catch (Ex) {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceAttachment.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceAttachment.ts
@@ -1,4 +1,5 @@
 export interface DeviceAttachment {
   guid: string;
   isImage: boolean;
+  created: Date;
 }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceAttachment.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceAttachment.ts
@@ -2,4 +2,5 @@ export interface DeviceAttachment {
   guid: string;
   isImage: boolean;
   created: Date;
+  name: string;
 }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceInfo.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceInfo.ts
@@ -8,4 +8,5 @@ export interface DeviceInfo {
   lastMessage?: Date;
   showWarning?: boolean;
   attachments: DeviceAttachment[];
+  defaultImageGuid: string;
 }

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -72,6 +72,23 @@ namespace EnvironmentMonitor.WebApi.Controllers
             return stream == null ? NotFound() : new FileStreamResult(stream.Stream, stream.ContentType);
         }
 
+        [HttpGet("default-image/{deviceId}")]
+        [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "image/jpeg")]
+        [Authorize(Roles = "Admin")]
+        public async Task<FileStreamResult?> GetDefaultImage([FromRoute] string deviceId)
+        {
+            var stream = await _deviceService.GetDefaultImage(deviceId);
+            return stream == null ? null : new FileStreamResult(stream.Stream, stream.ContentType);
+        }
+
+        [HttpPost("default-image")]
+        public async Task<DeviceInfoDto> SetDefaultImage([FromBody] SetDefaultImage model)
+        {
+            await _deviceService.SetDefaultImage(model.DeviceIdentifier, model.AttachmentGuid);
+            var res = await _deviceService.GetDeviceInfos(false, [model.DeviceIdentifier], true);
+            return res.FirstOrDefault();
+        }
+
         [HttpDelete("attachment/{deviceId}/{attachmentIdentifier}")]
         [Authorize(Roles = "Admin")]
         public async Task<DeviceInfoDto> DeleteAttachment([FromRoute] string deviceId, [FromRoute] Guid attachmentIdentifier)

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -82,6 +82,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         }
 
         [HttpPost("default-image")]
+        [Authorize(Roles = "Admin")]
         public async Task<DeviceInfoDto> SetDefaultImage([FromBody] SetDefaultImage model)
         {
             await _deviceService.SetDefaultImage(model.DeviceIdentifier, model.AttachmentGuid);

--- a/src/EnvironmentMonitor.WebApi/Services/ApiExceptionHandler.cs
+++ b/src/EnvironmentMonitor.WebApi/Services/ApiExceptionHandler.cs
@@ -20,7 +20,7 @@ namespace EnvironmentMonitor.WebApi.Services
             _logger.LogError(exception, "WebApi exception occured");
             var problemDetails = new ProblemDetails
             {
-                Title = "An error occurred",
+                Title =  "An error occurred",
                 Status = StatusCodes.Status500InternalServerError,
                 Detail = ""
             };
@@ -37,7 +37,7 @@ namespace EnvironmentMonitor.WebApi.Services
                     problemDetails.Status = StatusCodes.Status403Forbidden;
                     break;
                 case ArgumentException argEx:
-                    problemDetails.Title = "Bad request";
+                    problemDetails.Title = exception?.Message ?? "Bad request";
                     problemDetails.Status = StatusCodes.Status400BadRequest;
                     break;
                 default:


### PR DESCRIPTION
- Added functionality for showing / setting default images of devices.
  - Default image is set in the UI in ``DeviceView``.
  - Backend changes to controller, repository and services.
  - Created and name properties added to ``DeviceAttachmentDto``. Name fetched from Attachments OriginalName column. 
- Default images are visible in the ``DevicesTable`` in Image-column. From there, the default image will be visible in a tooltip or if the icon is clicked, then in a dialog. 
- In ``DeviceView``, all the device images can be extended and shown in a dialog. There, also the created and name information of attachments is shown.