### PR TITLE
Show connected status for devices

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/DeviceStatusDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceStatusDto.cs
@@ -1,0 +1,29 @@
+﻿using AutoMapper;
+using EnvironmentMonitor.Application.Mappings;
+using EnvironmentMonitor.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnvironmentMonitor.Application.DTOs
+{
+    public class DeviceStatusDto : IMapFrom<DeviceStatus>
+    {
+        public DateTime Timestamp { get; set; }
+        public bool Status { get; set; }
+        public int DeviceId { get; set; }
+        public void Mapping(Profile profile)
+        {
+            profile.CreateMap<DeviceStatus, DeviceStatusDto>().ForMember(x => x.Timestamp, opt => opt.MapFrom(x => x.TimeStamp));
+        }
+    }
+
+    public class DeviceStatusModel
+    {
+        public required List<DeviceStatusDto> DeviceStatuses { get; set; }
+
+        public List<DeviceDto> Devices { get; set; } = [];
+    }
+}

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -20,7 +20,7 @@ namespace EnvironmentMonitor.Application.Interfaces
         public Task<List<SensorDto>> GetSensors(List<string> deviceIdentifiers);
         public Task<List<SensorDto>> GetSensors(List<int> deviceIds);
         public Task<SensorDto?> GetSensor(int deviceId, int sensorIdInternal, AccessLevels accessLevel);
-
+        public Task<DeviceStatusModel> GetDeviceStatus(GetDeviceStatusModel model);
         public Task AddAttachment(string deviceIdentifier, UploadAttachmentModel fileModel);
         public Task DeleteAttachment(string deviceIdentifier, Guid attachmentIdentifier);
         public Task<AttachmentDownloadModel?> GetAttachment(string deviceIdentifier, Guid attachmentIdentifier);

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -172,8 +172,15 @@ namespace EnvironmentMonitor.Application.Services
                     var matchingAttachment = infos.FirstOrDefault(x => x.Device.Id == info.Device.Id)?.Device.Attachments.FirstOrDefault(a => a.Guid == attachment.Guid)?.Attachment;
                     if (matchingAttachment != null)
                     {
-                        var blobInfo = await _storageClient.GetBlobInfo(matchingAttachment.Name);
-                        attachment.SizeInBytes = blobInfo.SizeInBytes;
+                        try
+                        {
+                            var blobInfo = await _storageClient.GetBlobInfo(matchingAttachment.Name);
+                            attachment.SizeInBytes = blobInfo.SizeInBytes;
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, $"Failed to fetch blob info for attachment: '{matchingAttachment.Name }'");
+                        }
                     }
 
                 }

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -257,5 +257,20 @@ namespace EnvironmentMonitor.Application.Services
             }
             await _deviceRepository.SetStatus(model, true);
         }
+
+        public async Task<DeviceStatusModel> GetDeviceStatus(GetDeviceStatusModel model)
+        {
+            if (!_userService.HasAccessToDevices(model.DeviceIds, AccessLevels.Read))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var returnList = await _deviceRepository.GetDevicesStatus(model);
+            return new DeviceStatusModel()
+            {
+                DeviceStatuses = _mapper.Map<List<DeviceStatusDto>>(returnList),
+
+            };
+        }
     }
 }

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -36,5 +36,7 @@ namespace EnvironmentMonitor.Domain.Interfaces
 
         public Task SetStatus(SetDeviceStatusModel status, bool saveChanges);
         public Task SaveChanges();
+
+        public Task<List<DeviceStatus>> GetDevicesStatus(GetDeviceStatusModel model);
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/GetDeviceStatusModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetDeviceStatusModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnvironmentMonitor.Domain.Models
+{
+    public class GetDeviceStatusModel
+    {
+        public required List<int> DeviceIds { get; set; }
+        public required DateTime From { get; set; }
+        public DateTime? To { get; set; }
+    }
+}

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -300,7 +300,8 @@ namespace EnvironmentMonitor.Infrastructure.Data
             listToReturn.AddRange(model.DeviceIds.Select(x => new DeviceStatus()
             {
                 TimeStamp = _dateService.CurrentTime(),
-                Status = listToReturn.OrderByDescending(x => x.TimeStamp).FirstOrDefault()?.Status ?? false
+                Status = listToReturn.Where(y => y.DeviceId == x).OrderByDescending(x => x.TimeStamp).FirstOrDefault()?.Status ?? false,
+                DeviceId = x
             }));
             return listToReturn;
         }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -283,7 +283,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             var listToReturn = new List<DeviceStatus>();
             foreach (var deviceId in model.DeviceIds)
             {
-                var latestStatusBeforeTimeRangeStart = await _context.DeviceStatusChanges.FirstOrDefaultAsync(x => x.DeviceId == deviceId && x.TimeStamp < model.From);
+                var latestStatusBeforeTimeRangeStart = await _context.DeviceStatusChanges.Where(x => x.DeviceId == deviceId && x.TimeStamp < model.From).OrderBy(x => x.TimeStamp).FirstOrDefaultAsync();
                 if (latestStatusBeforeTimeRangeStart != null)
                 {
                     listToReturn.Add(latestStatusBeforeTimeRangeStart);

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -4,18 +4,9 @@ using EnvironmentMonitor.Domain.Enums;
 using EnvironmentMonitor.Domain.Exceptions;
 using EnvironmentMonitor.Domain.Interfaces;
 using EnvironmentMonitor.Domain.Models;
-using EnvironmentMonitor.Domain.Entities;
-using Microsoft.Azure.Devices;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Device = EnvironmentMonitor.Domain.Entities.Device;
 using DeviceStatus = EnvironmentMonitor.Domain.Entities.DeviceStatus;
 
@@ -127,7 +118,6 @@ namespace EnvironmentMonitor.Infrastructure.Data
             var devices = query.Where(x => identifiers == null || identifiers.Contains(x.DeviceIdentifier));
             return await GetDeviceInfos(devices);
         }
-
 
         public async Task<List<DeviceEvent>> GetDeviceEvents(int id)
         {
@@ -293,10 +283,10 @@ namespace EnvironmentMonitor.Infrastructure.Data
             var listToReturn = new List<DeviceStatus>();
             foreach (var deviceId in model.DeviceIds)
             {
-                var latestStatus = await _context.DeviceStatusChanges.FirstOrDefaultAsync(x => x.DeviceId == deviceId && x.TimeStamp < model.From);
-                if (latestStatus != null)
+                var latestStatusBeforeTimeRangeStart = await _context.DeviceStatusChanges.FirstOrDefaultAsync(x => x.DeviceId == deviceId && x.TimeStamp < model.From);
+                if (latestStatusBeforeTimeRangeStart != null)
                 {
-                    listToReturn.Add(latestStatus);
+                    listToReturn.Add(latestStatusBeforeTimeRangeStart);
                 }
             }
 

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -4,6 +4,7 @@ using EnvironmentMonitor.Domain.Enums;
 using EnvironmentMonitor.Domain.Exceptions;
 using EnvironmentMonitor.Domain.Interfaces;
 using EnvironmentMonitor.Domain.Models;
+using EnvironmentMonitor.Domain.Entities;
 using Microsoft.Azure.Devices;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Device = EnvironmentMonitor.Domain.Entities.Device;
+using DeviceStatus = EnvironmentMonitor.Domain.Entities.DeviceStatus;
 
 namespace EnvironmentMonitor.Infrastructure.Data
 {
@@ -284,6 +286,16 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 await _context.SaveChangesAsync();
             }
+        }
+
+        public async Task<List<DeviceStatus>> GetDevicesStatus(GetDeviceStatusModel model)
+        {
+            var query = _context.DeviceStatusChanges.Where(
+                x => model.DeviceIds.Contains(x.DeviceId) &&
+                x.TimeStamp >= model.From && (model.To == null || x.TimeStamp < model.To)
+            ).OrderBy(x => x.TimeStamp);
+            // TODO Get first value before range start for each device?
+            return await query.ToListAsync();
         }
     }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -297,11 +297,10 @@ namespace EnvironmentMonitor.Infrastructure.Data
 
             var statusList = await query.ToListAsync();
             listToReturn.AddRange(statusList);
-
             listToReturn.AddRange(model.DeviceIds.Select(x => new DeviceStatus()
             {
                 TimeStamp = _dateService.CurrentTime(),
-                Status = statusList.OrderByDescending(x => x.TimeStamp).FirstOrDefault()?.Status ?? false
+                Status = listToReturn.OrderByDescending(x => x.TimeStamp).FirstOrDefault()?.Status ?? false
             }));
             return listToReturn;
         }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -292,7 +292,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
 
             var query = _context.DeviceStatusChanges.Where(
                 x => model.DeviceIds.Contains(x.DeviceId) &&
-                x.TimeStamp >= model.From && (model.To == null || x.TimeStamp < model.To)
+                x.TimeStamp >= model.From && (model.To == null || x.TimeStamp <= model.To)
             ).OrderBy(x => x.TimeStamp);
 
             var statusList = await query.ToListAsync();

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.7.7",
     "chart.js": "^4.4.6",
     "chartjs-adapter-moment": "^1.0.1",
+    "chartjs-plugin-zoom": "^2.2.0",
     "immer": "^10.1.1",
     "moment": "^2.30.1",
     "react": "^18.3.1",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -59,6 +59,7 @@ export interface MultiSensorGraphProps {
   stepped?: boolean;
   zoomable?: boolean;
   hideUseAutoScale?: boolean;
+  highlightPoints?: boolean;
   onSetAutoScale?: (state: boolean) => void;
   onRefresh?: () => void;
 }
@@ -93,6 +94,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   stepped,
   zoomable,
   hideUseAutoScale,
+  highlightPoints,
 }) => {
   const singleDevice = devices && devices.length === 1 ? devices[0] : undefined;
 
@@ -229,6 +231,10 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
       .filter((d) => !hiddenDatasetIds.some((h) => h === d.id))
       .some((d) => d.measurementType === MeasurementTypes.Light);
     return hasLightAxis;
+  };
+
+  const isTouchDevice = () => {
+    return window.matchMedia("(hover: none)").matches;
   };
 
   return (
@@ -403,6 +409,12 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
                           borderWidth: 1,
                           backgroundColor: "rgba(54,162,235,0.15)",
                         },
+                        pinch: { enabled: true },
+                        mode: "x",
+                        wheel: { enabled: true },
+                      },
+                      pan: {
+                        enabled: isTouchDevice(),
                         mode: "x",
                       },
                     }
@@ -410,7 +422,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
               },
               elements: {
                 point: {
-                  radius: 0,
+                  radius: highlightPoints ? 2 : 0,
                 },
               },
               responsive: true,

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -234,7 +234,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   };
 
   const isTouchDevice = () => {
-    return window.matchMedia("(hover: none)").matches;
+    return window.matchMedia("(pointer: coarse)").matches;
   };
 
   return (

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -57,7 +57,8 @@ export interface MultiSensorGraphProps {
   title?: string;
   useDynamicColors?: boolean;
   stepped?: boolean;
-  enableZoom?: boolean;
+  zoomable?: boolean;
+  hideUseAutoScale?: boolean;
   onSetAutoScale?: (state: boolean) => void;
   onRefresh?: () => void;
 }
@@ -90,7 +91,8 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   isLoading,
   useDynamicColors,
   stepped,
-  enableZoom,
+  zoomable,
+  hideUseAutoScale,
 }) => {
   const singleDevice = devices && devices.length === 1 ? devices[0] : undefined;
 
@@ -276,26 +278,28 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
             {getTitle()}
           </Typography>
         )}
-        <FormControlLabel
-          sx={{ marginLeft: 2 }}
-          control={
-            <Checkbox
-              checked={autoScale}
-              onChange={(e, c) => {
-                setAutoScale(c);
-                if (onSetAutoScale) {
-                  onSetAutoScale(c);
-                }
-              }}
-              inputProps={{ "aria-label": "controlled checkbox" }}
-            />
-          }
-          label="Auto scale"
-          componentsProps={{
-            typography: { fontSize: "14px" }, // Adjust font size
-          }}
-        />
-        {enableZoom || onRefresh !== undefined ? (
+        {!hideUseAutoScale && (
+          <FormControlLabel
+            sx={{ marginLeft: 2 }}
+            control={
+              <Checkbox
+                checked={autoScale}
+                onChange={(e, c) => {
+                  setAutoScale(c);
+                  if (onSetAutoScale) {
+                    onSetAutoScale(c);
+                  }
+                }}
+                inputProps={{ "aria-label": "controlled checkbox" }}
+              />
+            }
+            label="Auto scale"
+            componentsProps={{
+              typography: { fontSize: "14px" }, // Adjust font size
+            }}
+          />
+        )}
+        {zoomable || onRefresh !== undefined ? (
           <Box
             sx={{
               display: "flex",
@@ -304,7 +308,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
               gap: 1,
             }}
           >
-            {enableZoom && (
+            {zoomable && (
               <Button
                 variant="outlined"
                 onClick={() => {
@@ -390,7 +394,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
                     (event.native?.target as any).style.cursor = "default";
                   },
                 },
-                zoom: enableZoom
+                zoom: zoomable
                   ? {
                       zoom: {
                         drag: {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -54,6 +54,7 @@ export interface MultiSensorGraphProps {
   isLoading?: boolean;
   title?: string;
   useDynamicColors?: boolean;
+  stepped?: boolean;
   onSetAutoScale?: (state: boolean) => void;
   onRefresh?: () => void;
 }
@@ -69,6 +70,7 @@ interface GraphDataset {
   measurementType: MeasurementTypes;
   borderColor?: string;
   backgroundColor?: string;
+  stepped?: boolean;
 }
 
 export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
@@ -84,6 +86,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   title,
   isLoading,
   useDynamicColors,
+  stepped,
 }) => {
   const singleDevice = devices && devices.length === 1 ? devices[0] : undefined;
 
@@ -129,6 +132,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
             label: getSensorLabel(measurementsBySensor.sensorId, val),
             yAxisID: yAxisId,
             measurementType: val,
+            stepped: stepped,
             data: measurementsBySensor.measurements
               .filter((d) => d.typeId === val)
               .map((d) => ({ x: d.timestamp, y: d.sensorValue })),
@@ -155,6 +159,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
     model?.measurements.forEach((m) => {
       for (let item in MeasurementTypes) {
         let val = parseInt(MeasurementTypes[item]) as MeasurementTypes;
+
         if (m.minValues[val] !== undefined) {
           returnArray.push({
             min: m.minValues[val],

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -295,28 +295,33 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
             typography: { fontSize: "14px" }, // Adjust font size
           }}
         />
-        {enableZoom && (
-          <Button
-            variant="outlined"
-            onClick={() => {
-              handleResetZoom();
+        {enableZoom || onRefresh !== undefined ? (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              marginLeft: "auto",
+              gap: 1,
             }}
-            size="small"
-            sx={{ marginLeft: "auto" }}
           >
-            Reset zoom
-          </Button>
-        )}
-        {onRefresh && (
-          <Button
-            variant="outlined"
-            onClick={onRefresh}
-            size="small"
-            sx={{ marginLeft: "auto" }}
-          >
-            Refresh
-          </Button>
-        )}
+            {enableZoom && (
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  handleResetZoom();
+                }}
+                size="small"
+              >
+                Reset zoom
+              </Button>
+            )}
+            {onRefresh && (
+              <Button variant="outlined" onClick={onRefresh} size="small">
+                Refresh
+              </Button>
+            )}
+          </Box>
+        ) : null}
       </Box>
       <Box
         flex={1}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -468,6 +468,7 @@ export const DeviceView: React.FC = () => {
             zoomable
             hideInfo
             hideUseAutoScale
+            highlightPoints
             minHeight={400}
             isLoading={isLoadingDeviceStatus}
             model={

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -447,7 +447,7 @@ export const DeviceView: React.FC = () => {
             isLoading={isLoadingMeasurements}
           />
         </Collapsible>
-        <Collapsible title="Status">
+        <Collapsible title="Online status">
           <MultiSensorGraph
             title="Online status"
             sensors={
@@ -464,7 +464,8 @@ export const DeviceView: React.FC = () => {
                   ]
                 : []
             }
-            stepped={true}
+            stepped
+            enableZoom
             minHeight={400}
             isLoading={isLoadingDeviceStatus}
             model={

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -465,7 +465,9 @@ export const DeviceView: React.FC = () => {
                 : []
             }
             stepped
-            enableZoom
+            zoomable
+            hideInfo
+            hideUseAutoScale
             minHeight={400}
             isLoading={isLoadingDeviceStatus}
             model={
@@ -482,7 +484,7 @@ export const DeviceView: React.FC = () => {
                               return {
                                 sensorId: selectedDevice.device.id,
                                 sensorValue: d.status,
-                                typeId: MeasurementTypes.Motion,
+                                typeId: MeasurementTypes.Undefined,
                                 timestamp: d.timestamp,
                               };
                             })

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -19,6 +19,8 @@ import { Collapsible } from "../components/CollabsibleComponent";
 import { MultiSensorGraph } from "../components/MultiSensorGraph";
 import moment from "moment";
 import { MeasurementsViewModel } from "../models/measurementsBySensor";
+import { DeviceStatusModel } from "../models/deviceStatus";
+import { MeasurementTypes } from "../enums/measurementTypes";
 
 interface PromiseInfo {
   type: string;
@@ -30,9 +32,13 @@ export const DeviceView: React.FC = () => {
     undefined
   );
   const [deviceEvents, setDeviceEvents] = useState<DeviceEvent[]>([]);
+  const [deviceStatusModel, setDeviceStatusModel] = useState<
+    DeviceStatusModel | undefined
+  >(undefined);
 
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMeasurements, setIsLoadingMeasurments] = useState(false);
+  const [isLoadingDeviceStatus, setIsLoadingDeviceStatus] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
   const [model, setModel] = useState<MeasurementsViewModel | undefined>(
     undefined
@@ -94,6 +100,29 @@ export const DeviceView: React.FC = () => {
       })
       .finally(() => {
         setIsLoadingMeasurments(false);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDevice]);
+
+  useEffect(() => {
+    if (!selectedDevice) {
+      return;
+    }
+    const momentStart = moment()
+      .local(true)
+      .add(-1 * 7, "day")
+      .utc(true);
+    setIsLoadingDeviceStatus(true);
+    deviceHook
+      .getDeviceStatus([selectedDevice.device.id], momentStart, undefined)
+      .then((res) => {
+        setDeviceStatusModel(res);
+      })
+      .catch((er) => {
+        console.error(er);
+      })
+      .finally(() => {
+        setIsLoadingDeviceStatus(false);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDevice]);
@@ -416,6 +445,52 @@ export const DeviceView: React.FC = () => {
             useAutoScale
             onRefresh={loadMeasurements}
             isLoading={isLoadingMeasurements}
+          />
+        </Collapsible>
+        <Collapsible title="Status">
+          <MultiSensorGraph
+            title="Online status"
+            sensors={
+              selectedDevice
+                ? [
+                    {
+                      id: selectedDevice.device.id,
+                      sensorId: 1,
+                      name: selectedDevice.device.name,
+                      deviceId: selectedDevice.device.id,
+                      scaleMin: 0,
+                      scaleMax: 2,
+                    },
+                  ]
+                : []
+            }
+            stepped={true}
+            minHeight={400}
+            isLoading={isLoadingDeviceStatus}
+            model={
+              selectedDevice
+                ? {
+                    measurements: [
+                      {
+                        sensorId: selectedDevice.device.id,
+                        minValues: {},
+                        maxValues: {},
+                        latestValues: {},
+                        measurements: deviceStatusModel
+                          ? deviceStatusModel.deviceStatuses.map((d) => {
+                              return {
+                                sensorId: selectedDevice.device.id,
+                                sensorValue: d.status,
+                                typeId: MeasurementTypes.Motion,
+                                timestamp: d.timestamp,
+                              };
+                            })
+                          : [],
+                      },
+                    ],
+                  }
+                : undefined
+            }
           />
         </Collapsible>
         <Collapsible isOpen={true} title="Commands">

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -449,7 +449,7 @@ export const DeviceView: React.FC = () => {
         </Collapsible>
         <Collapsible title="Online status">
           <MultiSensorGraph
-            title="Online status"
+            title="Last 7 days"
             sensors={
               selectedDevice
                 ? [

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
@@ -14,6 +14,7 @@ import { DeviceEvent } from "../models/deviceEvent";
 import { useDispatch } from "react-redux";
 import { addNotification } from "../reducers/userInterfaceReducer";
 import { LocationModel } from "../models/location";
+import { DeviceStatusModel } from "../models/deviceStatus";
 
 interface ApiHook {
   userHook: userHook;
@@ -83,6 +84,11 @@ interface deviceHook {
     deviceIdentifier: string,
     attachmentIdentifier: string
   ) => Promise<DeviceInfo | undefined>;
+  getDeviceStatus: (
+    deviceIds: number[],
+    from: moment.Moment,
+    to?: moment.Moment
+  ) => Promise<DeviceStatusModel>;
 }
 
 const apiClient = axios.create({
@@ -383,6 +389,28 @@ export const useApiHook = (): ApiHook => {
           throw Ex;
         }
       },
+      getDeviceStatus: async (
+        deviceIds: number[],
+        from: moment.Moment,
+        to?: moment.Moment
+      ) => {
+        try {
+          let res = await apiClient.get<any, AxiosResponse<DeviceStatusModel>>(
+            `/api/devices/status`,
+            {
+              params: {
+                deviceIds: deviceIds,
+                from: from.toISOString(),
+                to: to ? to.toISOString() : undefined,
+              },
+            }
+          );
+          return res.data;
+        } catch (Ex) {
+          showError("Failed to fetch device status");
+          throw Ex;
+        }
+      },
     },
     locationHook: {
       getLocations: async () => {
@@ -399,3 +427,10 @@ export const useApiHook = (): ApiHook => {
     },
   };
 };
+/*
+  getDeviceStatus: (
+    deviceIds: number[],
+    from: Date,
+    to?: Date
+  ) => Promise<DeviceStatusModel>;
+*/

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceStatus.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceStatus.ts
@@ -1,0 +1,15 @@
+export interface DeviceStatus {
+  status: number;
+  deviceId: number;
+  timestamp: Date;
+}
+
+export interface DeviceStatusModel {
+  deviceStatuses: DeviceStatus[];
+}
+
+export interface GetDeviceStatusModel {
+  deviceIds: number[];
+  from: Date;
+  to?: Date;
+}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/measurement.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/measurement.ts
@@ -4,11 +4,3 @@ export interface Measurement {
   typeId: number;
   timestamp: Date;
 }
-
-/*
-        public int SensorId { get; set; }
-        public double SensorValue { get; set; }
-        public int TypeId { get; set; }
-        public DateTime TimeStamp { get; set; }
-
-*/

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/measurementsBySensor.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/measurementsBySensor.ts
@@ -1,4 +1,3 @@
-import { MeasurementTypes } from "../enums/measurementTypes";
 import { Measurement } from "./measurement";
 import { Sensor } from "./sensor";
 
@@ -9,10 +8,12 @@ export interface MeasurementsViewModel {
 export interface MeasurementsBySensor {
   sensorId: number;
   measurements: Measurement[];
-  minValues: Record<MeasurementTypes, Measurement>;
-  maxValues: Record<MeasurementTypes, Measurement>;
-  latestValues: Record<MeasurementTypes, Measurement>;
+  minValues: { [key: number]: Measurement };
+  maxValues: { [key: number]: Measurement };
+  latestValues: { [key: number]: Measurement };
 }
+
+// const myDict: { [key: number]: Measurement } = {};
 
 export interface MeasurementsModel {
   measurements: Measurement[];
@@ -21,9 +22,9 @@ export interface MeasurementsModel {
 
 export interface MeasurementsInfo {
   sensorId: number;
-  minValues: Record<MeasurementTypes, Measurement>;
-  maxValues: Record<MeasurementTypes, Measurement>;
-  latestValues: Record<MeasurementTypes, Measurement>;
+  minValues: { [key: number]: Measurement };
+  maxValues: { [key: number]: Measurement };
+  latestValues: { [key: number]: Measurement };
 }
 
 export interface MeasurementsByLocation {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/yarn.lock
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/yarn.lock
@@ -2449,6 +2449,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hammerjs@^2.0.45":
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
+  integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
+
 "@types/hoist-non-react-statics@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
@@ -3676,6 +3681,14 @@ chartjs-adapter-moment@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chartjs-adapter-moment/-/chartjs-adapter-moment-1.0.1.tgz#0f04c30d330b207c14bfb57dfaae9ce332f09102"
   integrity sha512-Uz+nTX/GxocuqXpGylxK19YG4R3OSVf8326D+HwSTsNw1LgzyIGRo+Qujwro1wy6X+soNSnfj5t2vZ+r6EaDmA==
+
+chartjs-plugin-zoom@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz#79928acf2d22bd60b5442e0ef73139b261c65d19"
+  integrity sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==
+  dependencies:
+    "@types/hammerjs" "^2.0.45"
+    hammerjs "^2.0.8"
 
 check-types@^11.2.3:
   version "11.2.3"
@@ -5649,6 +5662,11 @@ gzip-size@^6.0.0:
   integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
   dependencies:
     duplexer "^0.1.2"
+
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==
 
 handle-thing@^2.0.0:
   version "2.0.1"

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -140,5 +140,11 @@ namespace EnvironmentMonitor.WebApi.Controllers
             var result = await _deviceService.GetSensors(deviceIds);
             return result;
         }
+
+        [HttpGet("status")]
+        public async Task<DeviceStatusModel> GetDeviceStatus([FromQuery] GetDeviceStatusModel model)
+        {
+            return await _deviceService.GetDeviceStatus(model);
+        }
     }
 }


### PR DESCRIPTION
Device connected status is now shown for devices

- Backend changes:
  - New DTO
  - End point in ``DevicesController``, new method in ``DeviceService``, fetching logic in ``DeviceRepository``
  - If blob info cannot be retrieved, just log the exceptions.
- UI
  - Connection status shown using ``MultiSensorGraph`` in ``DeviceView``
  - Zooming support for ``MultiSensorGraph`` + other minorish changes
  - Replaced record types with dict.