### PR TITLE
Changes to build pipeline

### DIFF
--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -63,18 +63,18 @@ jobs:
         run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -r win-x86 -o "${{env.DOTNET_ROOT}}/env-monitor-web-api"
 
       - name: dotnet publish (Function)
-        run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -o "${{env.DOTNET_ROOT}}/env-monitor-function"
+        run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r win-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-function"
 
       - name: Upload web api artifact
         uses: actions/upload-artifact@v4
         with:
-          name: .env-monitor-web-api
+          name: .env-monitor-web-api_x86
           path: ${{env.DOTNET_ROOT}}/env-monitor-web-api
 
       - name: Upload function artifact
         uses: actions/upload-artifact@v4
         with:
-          name: .env-monitor-function
+          name: .env-monitor-function_x64
           path: ${{env.DOTNET_ROOT}}/env-monitor-function
           include-hidden-files: true
   deploy:
@@ -92,13 +92,13 @@ jobs:
       - name: Download WEB API artifacts
         uses: actions/download-artifact@v4
         with:
-          name: .env-monitor-web-api
+          name: .env-monitor-web-api_x86
           path: "./env-monitor-web-api"
 
       - name: Download HubObserver artifacts
         uses: actions/download-artifact@v4
         with:
-          name: .env-monitor-function
+          name: .env-monitor-function_x64
           path: "./env-monitor-function"
 
       - name: Login to Azure

--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -60,7 +60,7 @@ jobs:
           cp -r src/EnvironmentMonitor.ReactUi/environment-monitor/dist/ src/EnvironmentMonitor.WebApi/wwwroot/
 
       - name: dotnet publish (WebApi)
-        run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -o "${{env.DOTNET_ROOT}}/env-monitor-web-api"
+        run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -r win-x86 -o "${{env.DOTNET_ROOT}}/env-monitor-web-api"
 
       - name: dotnet publish (Function)
         run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -o "${{env.DOTNET_ROOT}}/env-monitor-function"

--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -59,23 +59,42 @@ jobs:
         run: |
           cp -r src/EnvironmentMonitor.ReactUi/environment-monitor/dist/ src/EnvironmentMonitor.WebApi/wwwroot/
 
-      - name: dotnet publish (WebApi)
-        run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -r win-x86 -o "${{env.DOTNET_ROOT}}/env-monitor-web-api"
+      - name: dotnet publish (WebApi) (win-x86)
+        run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -r win-x86 -o "${{env.DOTNET_ROOT}}/env-monitor-web-api_x86"
 
-      - name: dotnet publish (Function)
-        run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r win-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-function"
+      - name: dotnet publish (WebApi) (win-x64)
+        run: dotnet publish src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj -c Release -r win-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-web-api_x64"
 
-      - name: Upload web api artifact
+      - name: dotnet publish (Function) (win-x86)
+        run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r win-x86 -o "${{env.DOTNET_ROOT}}/env-monitor-function_x86"
+
+      - name: dotnet publish (Function) (win-x64)
+        run: dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r win-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-function_x64"
+
+      - name: Upload web api artifact (win-x86)
         uses: actions/upload-artifact@v4
         with:
           name: .env-monitor-web-api_x86
-          path: ${{env.DOTNET_ROOT}}/env-monitor-web-api
+          path: ${{env.DOTNET_ROOT}}/env-monitor-web-api_x86
 
-      - name: Upload function artifact
+      - name: Upload web api artifact (win-x64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: .env-monitor-web-api_x64
+          path: ${{env.DOTNET_ROOT}}/env-monitor-web-api_x64
+
+      - name: Upload function artifact (win-x86)
+        uses: actions/upload-artifact@v4
+        with:
+          name: .env-monitor-function_x86
+          path: ${{env.DOTNET_ROOT}}/env-monitor-function_x86
+          include-hidden-files: true
+
+      - name: Upload function artifact (win-x64)
         uses: actions/upload-artifact@v4
         with:
           name: .env-monitor-function_x64
-          path: ${{env.DOTNET_ROOT}}/env-monitor-function
+          path: ${{env.DOTNET_ROOT}}/env-monitor-function_x64
           include-hidden-files: true
   deploy:
     runs-on: windows-latest


### PR DESCRIPTION
Magick.net library takes a lot of space, so publish only win-x86 and win-x64 versions of web api and the function. Magick.net has a native implementation for different runtimes. win-x64 + win-x64 are sufficient for the current usage in Azure.

These changes were applied in order to reduce the size of the package deployed, as there were some issues with the app service deployment for large packages.