### PR TITLE
Minor optimization

### DIFF
--- a/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceMessageConfiguration.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceMessageConfiguration.cs
@@ -14,8 +14,9 @@ namespace EnvironmentMonitor.Infrastructure.Data.Configurations
         public void Configure(EntityTypeBuilder<DeviceMessage> builder)
         {
             builder.HasKey(d => d.Id);
-
             builder.HasMany(x => x.Measurements).WithOne(x => x.DeviceMessage).IsRequired(false);
+            builder.HasIndex(x => new { x.DeviceId, x.TimeStamp });
+            builder.HasIndex(x => x.TimeStamp);
         }
     }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -248,7 +248,11 @@ namespace EnvironmentMonitor.Infrastructure.Data
             bool statusToSet;
             var device = await _context.Devices.FirstOrDefaultAsync(x => x.Id == model.DeviceId) ?? throw new EntityNotFoundException();
             var latestStatus = await _context.DeviceStatusChanges.Where(x => x.DeviceId == device.Id).OrderByDescending(x => x.TimeStamp).FirstOrDefaultAsync();
-            var latestMessage = await _context.Measurements.Where(x => x.Sensor.DeviceId == device.Id).OrderByDescending(x => x.Timestamp).FirstOrDefaultAsync();
+            var latestMessage = await _context.Measurements.Where(x => 
+                x.Sensor.DeviceId == device.Id
+                && x.Timestamp > _dateService.CurrentTime().AddDays(-1) // Optimization
+            ).OrderByDescending(x => x.Timestamp).FirstOrDefaultAsync();
+
             if (model.Status != null)
             {
                 statusToSet = model.Status.Value;

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250511194612_AddIndexesOnDeviceMessages.Designer.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250511194612_AddIndexesOnDeviceMessages.Designer.cs
@@ -4,6 +4,7 @@ using EnvironmentMonitor.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnvironmentMonitor.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(MeasurementDbContext))]
-    partial class MeasurementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250511194612_AddIndexesOnDeviceMessages")]
+    partial class AddIndexesOnDeviceMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250511194612_AddIndexesOnDeviceMessages.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250511194612_AddIndexesOnDeviceMessages.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnvironmentMonitor.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIndexesOnDeviceMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceMessages_DeviceId",
+                table: "DeviceMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceMessages_DeviceId_TimeStamp",
+                table: "DeviceMessages",
+                columns: new[] { "DeviceId", "TimeStamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceMessages_TimeStamp",
+                table: "DeviceMessages",
+                column: "TimeStamp");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceMessages_DeviceId_TimeStamp",
+                table: "DeviceMessages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceMessages_TimeStamp",
+                table: "DeviceMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceMessages_DeviceId",
+                table: "DeviceMessages",
+                column: "DeviceId");
+        }
+    }
+}


### PR DESCRIPTION
- Optimized ``SetStatus`` in ``DeviceRepository`` by applying a range for measurements to check. Now, only measurements that are less than one day old are checked. This way the index is better hit. Without a timestamp filter, the query was very slow in case there were no measurements for the device in question. 
- Added indexes to DeviceMessages table