### PR TITLE
Refactoring and general changes for devices

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
@@ -18,10 +18,12 @@ namespace EnvironmentMonitor.Application.DTOs
         public bool Visible { get; set; }
         public bool HasMotionSensor { get; set; }
         public int LocationId { get; set; }
+        public string? DisplayName { get; set; }
 
         public void Mapping(Profile profile)
         {
             profile.CreateMap<Device, DeviceDto>()
+                .ForMember(x => x.DisplayName, opt => opt.MapFrom(x => x.Location != null ? $"{x.Location.Name} - {x.Name}" : x.Name))
                 .ReverseMap();
         }
     }

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
@@ -12,7 +12,7 @@ namespace EnvironmentMonitor.Application.DTOs
     public class DeviceDto : IMapFrom<Device>
     {
         public int Id { get; set; }
-        public Guid DeviceIdentifier { get; set; }
+        public Guid Identifier { get; set; }
         public string Name { get; set; }
         public List<SensorDto> Sensors { get; set; } = [];
         public bool Visible { get; set; }
@@ -22,7 +22,6 @@ namespace EnvironmentMonitor.Application.DTOs
         public void Mapping(Profile profile)
         {
             profile.CreateMap<Device, DeviceDto>()
-                .ForMember(x => x.DeviceIdentifier, opt => opt.MapFrom(x => x.Identifier))
                 .ReverseMap();
         }
     }

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
@@ -12,7 +12,7 @@ namespace EnvironmentMonitor.Application.DTOs
     public class DeviceDto : IMapFrom<Device>
     {
         public int Id { get; set; }
-        public string DeviceIdentifier { get; set; }
+        public Guid DeviceIdentifier { get; set; }
         public string Name { get; set; }
         public List<SensorDto> Sensors { get; set; } = [];
         public bool Visible { get; set; }
@@ -22,6 +22,7 @@ namespace EnvironmentMonitor.Application.DTOs
         public void Mapping(Profile profile)
         {
             profile.CreateMap<Device, DeviceDto>()
+                .ForMember(x => x.DeviceIdentifier, opt => opt.MapFrom(x => x.Identifier))
                 .ReverseMap();
         }
     }

--- a/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceDto.cs
@@ -17,6 +17,7 @@ namespace EnvironmentMonitor.Application.DTOs
         public List<SensorDto> Sensors { get; set; } = [];
         public bool Visible { get; set; }
         public bool HasMotionSensor { get; set; }
+        public int LocationId { get; set; }
 
         public void Mapping(Profile profile)
         {

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -11,24 +11,29 @@ namespace EnvironmentMonitor.Application.Interfaces
 {
     public interface IDeviceService
     {
-        public Task Reboot(string deviceIdentifier);
-        public Task SetMotionControlStatus(string deviceIdentifier, MotionControlStatus status);
-        public Task SetMotionControlDelay(string deviceIdentifier, long delayMs);
+        public Task Reboot(Guid identifier);
+        public Task SetMotionControlStatus(Guid identifier, MotionControlStatus status);
+        public Task SetMotionControlDelay(Guid identifier, long delayMs);
+
         public Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel);
+        public Task<DeviceDto> GetDevice(Guid identifier, AccessLevels accessLevel);
+
         public Task<List<DeviceDto>> GetDevices();
-        public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<string>? identifiers, bool getAttachments = false);
-        public Task<List<SensorDto>> GetSensors(List<string> deviceIdentifiers);
+        public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false);
+        public Task<List<SensorDto>> GetSensors(List<Guid> identifiers);
         public Task<List<SensorDto>> GetSensors(List<int> deviceIds);
+
         public Task<SensorDto?> GetSensor(int deviceId, int sensorIdInternal, AccessLevels accessLevel);
+
         public Task<DeviceStatusModel> GetDeviceStatus(GetDeviceStatusModel model);
-        public Task AddAttachment(string deviceIdentifier, UploadAttachmentModel fileModel);
-        public Task DeleteAttachment(string deviceIdentifier, Guid attachmentIdentifier);
-        public Task<AttachmentDownloadModel?> GetAttachment(string deviceIdentifier, Guid attachmentIdentifier);
-        public Task<AttachmentDownloadModel?> GetDefaultImage(string deviceIdentifier);
-        public Task SetDefaultImage(string deviceIdentifier, Guid attachmentGuid);
+        public Task AddAttachment(Guid identifier, UploadAttachmentModel fileModel);
+        public Task DeleteAttachment(Guid identifier, Guid attachmentIdentifier);
+        public Task<AttachmentDownloadModel?> GetAttachment(Guid identifier, Guid attachmentIdentifier);
+        public Task<AttachmentDownloadModel?> GetDefaultImage(Guid identifier);
+        public Task SetDefaultImage(Guid identifier, Guid attachmentGuid);
 
         public Task AddEvent(int deviceId, DeviceEventTypes type, string message, bool saveChanges, DateTime? datetimeUtc = null);
-        public Task<List<DeviceEventDto>> GetDeviceEvents(string identifier);
+        public Task<List<DeviceEventDto>> GetDeviceEvents(Guid identifier);
         public Task SetStatus(SetDeviceStatusModel model);
 
         public Task<DeviceInfoDto> UpdateDevice(UpdateDeviceDto model);

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -19,7 +19,7 @@ namespace EnvironmentMonitor.Application.Interfaces
         public Task<DeviceDto> GetDevice(Guid identifier, AccessLevels accessLevel);
 
         public Task<List<DeviceDto>> GetDevices(bool onlyVisible, bool getLocation);
-        public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false);
+        public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false, bool getLocation = false);
         public Task<List<SensorDto>> GetSensors(List<Guid> identifiers);
         public Task<List<SensorDto>> GetSensors(List<int> deviceIds);
 

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -18,7 +18,7 @@ namespace EnvironmentMonitor.Application.Interfaces
         public Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel);
         public Task<DeviceDto> GetDevice(Guid identifier, AccessLevels accessLevel);
 
-        public Task<List<DeviceDto>> GetDevices(bool onlyVisible);
+        public Task<List<DeviceDto>> GetDevices(bool onlyVisible, bool getLocation);
         public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false);
         public Task<List<SensorDto>> GetSensors(List<Guid> identifiers);
         public Task<List<SensorDto>> GetSensors(List<int> deviceIds);

--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceService.cs
@@ -18,7 +18,7 @@ namespace EnvironmentMonitor.Application.Interfaces
         public Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel);
         public Task<DeviceDto> GetDevice(Guid identifier, AccessLevels accessLevel);
 
-        public Task<List<DeviceDto>> GetDevices();
+        public Task<List<DeviceDto>> GetDevices(bool onlyVisible);
         public Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false);
         public Task<List<SensorDto>> GetSensors(List<Guid> identifiers);
         public Task<List<SensorDto>> GetSensors(List<int> deviceIds);

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -205,7 +205,7 @@ namespace EnvironmentMonitor.Application.Services
         {
             var device = await GetDevice(identifier, AccessLevels.Write);
             var extension = Path.GetExtension(fileModel.FileName);
-            var fileNameToSave = $"{device.DeviceIdentifier}_{Guid.NewGuid()}{extension}";
+            var fileNameToSave = $"{device.Identifier}_{Guid.NewGuid()}{extension}";
             var res = await _storageClient.Upload(new UploadAttachmentModel()
             {
                 FileName = fileNameToSave,

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -185,13 +185,20 @@ namespace EnvironmentMonitor.Application.Services
             await _deviceRepository.AddEvent(deviceId, type, message, saveChanges, datetimeUtc);
         }
 
-        public async Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false)
+        public async Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false, bool getLocation = false)
         {
             _logger.LogInformation($"Fetching device infos. Identifiers: {string.Join(",", identifiers ?? [])}");
             var infos = new List<DeviceInfo>();
             if (identifiers?.Any() == true)
             {
-                infos = (await _deviceRepository.GetDeviceInfo(new GetDevicesModel() { Identifiers = identifiers, OnlyVisible = onlyVisible, GetAttachments = getAttachments })).Where(d => _userService.HasAccessToDevice(d.Device.Id, AccessLevels.Read)).ToList();
+                infos = (await _deviceRepository.GetDeviceInfo(new GetDevicesModel()
+                {
+                    Identifiers = identifiers,
+                    OnlyVisible = onlyVisible,
+                    GetAttachments = getAttachments,
+                    GetLocation = getLocation
+                }))
+                .Where(d => _userService.HasAccessToDevice(d.Device.Id, AccessLevels.Read)).ToList();
             }
             else
             {
@@ -199,7 +206,8 @@ namespace EnvironmentMonitor.Application.Services
                 {
                     Ids = _userService.IsAdmin ? null : _userService.GetDevices(),
                     OnlyVisible = onlyVisible,
-                    GetAttachments = getAttachments
+                    GetAttachments = getAttachments,
+                    GetLocation = getLocation
                 });
             }
             var listToReturn = _mapper.Map<List<DeviceInfoDto>>(infos);

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -39,49 +39,41 @@ namespace EnvironmentMonitor.Application.Services
             _dateService = dateService;
             _imageService = imageService;
         }
-        public async Task Reboot(string deviceIdentifier)
+        public async Task Reboot(Guid identifier)
         {
             if (!_userService.IsAdmin)
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
-            _logger.LogInformation($"Trying to reboot device with identifier '{deviceIdentifier}'");
-            await _messageService.SendMessageToDevice(deviceIdentifier, "REBOOT");
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { Identifiers = [identifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{identifier}' not found.");
+            _logger.LogInformation($"Trying to reboot device with identifier '{identifier}'");
+            await _messageService.SendMessageToDevice(device.DeviceIdentifier, "REBOOT");
             await AddEvent(device.Id, DeviceEventTypes.RebootCommand, "Rebooted by UI", true);
         }
 
-        public async Task SetMotionControlStatus(string deviceIdentifier, MotionControlStatus status)
+        public async Task SetMotionControlStatus(Guid identifier, MotionControlStatus status)
         {
             if (!_userService.IsAdmin)
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
-            if (device == null)
-            {
-                throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
-            }
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { Identifiers = [identifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{identifier}' not found.");
             var message = $"MOTIONCONTROLSTATUS:{(int)status}";
             _logger.LogInformation($"Sending message: '{message}' to device: {device.Id}");
-            await _messageService.SendMessageToDevice(deviceIdentifier, message);
+            await _messageService.SendMessageToDevice(device.DeviceIdentifier, message);
             await AddEvent(device.Id, DeviceEventTypes.SetMotionControlStatus, $"Motion control status set to: {(int)status} ({status.ToString()})", true);
         }
 
-        public async Task SetMotionControlDelay(string deviceIdentifier, long delayMs)
+        public async Task SetMotionControlDelay(Guid identifier, long delayMs)
         {
             if (!_userService.IsAdmin)
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
-            if (device == null)
-            {
-                throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
-            }
-            var message = $"MOTIONCONTROLDELAY:{delayMs}";
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { Identifiers = [identifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{identifier}' not found.");
+            var message = $"MOTIONCONTROLDELAY: {delayMs}";
             _logger.LogInformation($"Sending message: '{message}' to device: {device.Id}");
-            await _messageService.SendMessageToDevice(deviceIdentifier, message);
+            await _messageService.SendMessageToDevice(device.DeviceIdentifier, message);
             await AddEvent(device.Id, DeviceEventTypes.SetMotionControlStatus, $"Motion control delay set to: {(int)delayMs} ms", true);
         }
 
@@ -91,9 +83,9 @@ namespace EnvironmentMonitor.Application.Services
             return _mapper.Map<List<DeviceDto>>(devices);
         }
 
-        public async Task<List<SensorDto>> GetSensors(List<string> deviceIdentifiers)
+        public async Task<List<SensorDto>> GetSensors(List<Guid> identifiers )
         {
-            var sensors = await _deviceRepository.GetSensors(new GetDeviceModel() { DeviceIdentifiers = deviceIdentifiers });
+            var sensors = await _deviceRepository.GetSensors(new GetDeviceModel() { Identifiers = identifiers });
             sensors = sensors.Where(s => _userService.HasAccessToSensor(s.Id, AccessLevels.Read));
             return _mapper.Map<List<SensorDto>>(sensors);
         }
@@ -108,6 +100,17 @@ namespace EnvironmentMonitor.Application.Services
         public async Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel)
         {
             var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
+            if (device == null || !_userService.HasAccessToDevice(device.Id, accessLevel))
+            {
+                throw new UnauthorizedAccessException();
+            }
+            var mapped = _mapper.Map<DeviceDto>(device);
+            return mapped;
+        }
+
+        public async Task<DeviceDto> GetDevice(Guid identifier, AccessLevels accessLevel)
+        {
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { Identifiers = [identifier] })).FirstOrDefault();
             if (device == null || !_userService.HasAccessToDevice(device.Id, accessLevel))
             {
                 throw new UnauthorizedAccessException();
@@ -150,13 +153,13 @@ namespace EnvironmentMonitor.Application.Services
             await _deviceRepository.AddEvent(deviceId, type, message, saveChanges, datetimeUtc);
         }
 
-        public async Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<string>? identifiers, bool getAttachments = false)
+        public async Task<List<DeviceInfoDto>> GetDeviceInfos(bool onlyVisible, List<Guid>? identifiers, bool getAttachments = false)
         {
             _logger.LogInformation($"Fetching device infos. Identifiers: {string.Join(",", identifiers ?? [])}");
             var infos = new List<DeviceInfo>();
             if (identifiers?.Any() == true)
             {
-                infos = (await _deviceRepository.GetDeviceInfo(new GetDeviceModel() { DeviceIdentifiers = identifiers, OnlyVisible = onlyVisible, GetAttachments = getAttachments })).Where(d => _userService.HasAccessToDevice(d.Device.Id, AccessLevels.Read)).ToList();
+                infos = (await _deviceRepository.GetDeviceInfo(new GetDeviceModel() { Identifiers = identifiers, OnlyVisible = onlyVisible, GetAttachments = getAttachments })).Where(d => _userService.HasAccessToDevice(d.Device.Id, AccessLevels.Read)).ToList();
             }
             else
             {
@@ -191,18 +194,18 @@ namespace EnvironmentMonitor.Application.Services
             return listToReturn;
         }
 
-        public async Task<List<DeviceEventDto>> GetDeviceEvents(string identifier)
+        public async Task<List<DeviceEventDto>> GetDeviceEvents(Guid identifier)
         {
             var device = await GetDevice(identifier, AccessLevels.Read) ?? throw new UnauthorizedAccessException();
             var events = await _deviceRepository.GetDeviceEvents(device.Id);
             return _mapper.Map<List<DeviceEventDto>>(events);
         }
 
-        public async Task AddAttachment(string deviceIdentifier, UploadAttachmentModel fileModel)
+        public async Task AddAttachment(Guid identifier, UploadAttachmentModel fileModel)
         {
-            var device = await GetDevice(deviceIdentifier, AccessLevels.Write);
+            var device = await GetDevice(identifier, AccessLevels.Write);
             var extension = Path.GetExtension(fileModel.FileName);
-            var fileNameToSave = $"{deviceIdentifier}_{Guid.NewGuid()}{extension}";
+            var fileNameToSave = $"{device.DeviceIdentifier}_{Guid.NewGuid()}{extension}";
             var res = await _storageClient.Upload(new UploadAttachmentModel()
             {
                 FileName = fileNameToSave,
@@ -223,25 +226,25 @@ namespace EnvironmentMonitor.Application.Services
             true);
         }
 
-        public async Task DeleteAttachment(string deviceIdentifier, Guid attachmentIdentifier)
+        public async Task DeleteAttachment(Guid identifier, Guid attachmentIdentifier)
         {
-            _logger.LogInformation($"Removing attachment with identifier: '{attachmentIdentifier}' for device with identifier: '{deviceIdentifier}'");
-            var device = await GetDevice(deviceIdentifier, AccessLevels.Write);
+            _logger.LogInformation($"Removing attachment with identifier: '{attachmentIdentifier}' for device with identifier: '{identifier}'");
+            var device = await GetDevice(identifier, AccessLevels.Write);
             var attachment = await _deviceRepository.GetAttachment(device.Id, attachmentIdentifier);
             await _deviceRepository.DeleteAttachment(device.Id, attachmentIdentifier, true);
             await _storageClient.DeleteBlob(attachment.Name);
         }
 
-        public async Task<AttachmentDownloadModel?> GetAttachment(string deviceIdentifier, Guid attachmentIdentifier)
+        public async Task<AttachmentDownloadModel?> GetAttachment(Guid identifier, Guid attachmentIdentifier)
         {
-            _logger.LogInformation($"Trying to get attachment with identifier '{attachmentIdentifier}' for device: '{deviceIdentifier}'");
-            var device = await GetDevice(deviceIdentifier, AccessLevels.Write);
+            _logger.LogInformation($"Trying to get attachment with identifier '{attachmentIdentifier}' for device: '{identifier}'");
+            var device = await GetDevice(identifier, AccessLevels.Write);
             var attachment = await _deviceRepository.GetAttachment(device.Id, attachmentIdentifier);
             return await _storageClient.GetImageAsync(attachment.Name);
         }
-        public async Task<AttachmentDownloadModel?> GetDefaultImage(string deviceIdentifier)
+        public async Task<AttachmentDownloadModel?> GetDefaultImage(Guid identifier)
         {
-            var device = await GetDevice(deviceIdentifier, AccessLevels.Read);
+            var device = await GetDevice(identifier, AccessLevels.Read);
             var deviceInfo = (await _deviceRepository.GetDeviceInfo(new GetDeviceModel() { Ids = [device.Id], GetAttachments = true, OnlyVisible = false })).FirstOrDefault();
             var attachment = deviceInfo?.Device.Attachments.FirstOrDefault(x => x.IsDefaultImage);
             if (attachment == null)
@@ -251,10 +254,10 @@ namespace EnvironmentMonitor.Application.Services
             return await _storageClient.GetImageAsync(attachment.Attachment.Name);
         }
 
-        public async Task SetDefaultImage(string deviceIdentifier, Guid attachmentGuid)
+        public async Task SetDefaultImage(Guid identifier, Guid attachmentGuid)
         {
-            _logger.LogInformation($"Setting default image for device '{deviceIdentifier}'");
-            var device = await GetDevice(deviceIdentifier, AccessLevels.Write);
+            _logger.LogInformation($"Setting default image for device '{identifier}'");
+            var device = await GetDevice(identifier, AccessLevels.Write);
             await _deviceRepository.SetDefaultImage(device.Id, attachmentGuid);
         }
 

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -45,7 +45,7 @@ namespace EnvironmentMonitor.Application.Services
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = await _deviceRepository.GetDeviceByIdentifier(deviceIdentifier) ?? throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
             _logger.LogInformation($"Trying to reboot device with identifier '{deviceIdentifier}'");
             await _messageService.SendMessageToDevice(deviceIdentifier, "REBOOT");
             await AddEvent(device.Id, DeviceEventTypes.RebootCommand, "Rebooted by UI", true);
@@ -57,7 +57,7 @@ namespace EnvironmentMonitor.Application.Services
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = await _deviceRepository.GetDeviceByIdentifier(deviceIdentifier);
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
             if (device == null)
             {
                 throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
@@ -74,7 +74,7 @@ namespace EnvironmentMonitor.Application.Services
             {
                 throw new UnauthorizedAccessException();
             }
-            var device = await _deviceRepository.GetDeviceByIdentifier(deviceIdentifier);
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
             if (device == null)
             {
                 throw new EntityNotFoundException($"Device with identifier: '{deviceIdentifier}' not found.");
@@ -107,8 +107,7 @@ namespace EnvironmentMonitor.Application.Services
 
         public async Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel)
         {
-            var device = await _deviceRepository.GetDeviceByIdentifier(deviceIdentifier);
-
+            var device = (await _deviceRepository.GetDevices(new GetDeviceModel() { DeviceIdentifiers = [deviceIdentifier] })).FirstOrDefault();
             if (device == null || !_userService.HasAccessToDevice(device.Id, accessLevel))
             {
                 throw new UnauthorizedAccessException();
@@ -195,7 +194,7 @@ namespace EnvironmentMonitor.Application.Services
         public async Task<List<DeviceEventDto>> GetDeviceEvents(string identifier)
         {
             var device = await GetDevice(identifier, AccessLevels.Read) ?? throw new UnauthorizedAccessException();
-            var events = await _deviceRepository.GetDeviceEvents(identifier);
+            var events = await _deviceRepository.GetDeviceEvents(device.Id);
             return _mapper.Map<List<DeviceEventDto>>(events);
         }
 

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -93,7 +93,7 @@ namespace EnvironmentMonitor.Application.Services
 
         public async Task<List<SensorDto>> GetSensors(List<string> deviceIdentifiers)
         {
-            var sensors = await _deviceRepository.GetSensorsByDeviceIdentifiers(deviceIdentifiers);
+            var sensors = await _deviceRepository.GetSensors(new GetDeviceModel() { DeviceIdentifiers = deviceIdentifiers });
             sensors = sensors.Where(s => _userService.HasAccessToSensor(s.Id, AccessLevels.Read));
             return _mapper.Map<List<SensorDto>>(sensors);
         }
@@ -101,8 +101,8 @@ namespace EnvironmentMonitor.Application.Services
         public async Task<List<SensorDto>> GetSensors(List<int> deviceIds)
         {
             var sensors = new List<SensorDto>();
-            var res = await _deviceRepository.GetSensorsByDeviceIdsAsync(deviceIds.Where(d => _userService.HasAccessToDevice(d, AccessLevels.Read)).ToList());
-            return _mapper.Map<List<SensorDto>>(res);
+            var res = await _deviceRepository.GetSensors(new GetDeviceModel() { Ids = deviceIds.Where(d => _userService.HasAccessToDevice(d, AccessLevels.Read)).ToList() });
+            return _mapper.Map<List<SensorDto>>(res.ToList());
         }
 
         public async Task<DeviceDto> GetDevice(string deviceIdentifier, AccessLevels accessLevel)

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -77,9 +77,14 @@ namespace EnvironmentMonitor.Application.Services
             await AddEvent(device.Id, DeviceEventTypes.SetMotionControlStatus, $"Motion control delay set to: {(int)delayMs} ms", true);
         }
 
-        public async Task<List<DeviceDto>> GetDevices(bool onlyVisible)
+        public async Task<List<DeviceDto>> GetDevices(bool onlyVisible, bool getLocation)
         {
-            var devices = await _deviceRepository.GetDevices(new GetDevicesModel() { Ids = _userService.IsAdmin ? null : _userService.GetDevices(), OnlyVisible = true });
+            var devices = await _deviceRepository.GetDevices(new GetDevicesModel()
+            {
+                Ids = _userService.IsAdmin ? null : _userService.GetDevices(),
+                OnlyVisible = onlyVisible,
+                GetLocation = getLocation
+            });
             return _mapper.Map<List<DeviceDto>>(devices);
         }
 

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -77,9 +77,9 @@ namespace EnvironmentMonitor.Application.Services
             await AddEvent(device.Id, DeviceEventTypes.SetMotionControlStatus, $"Motion control delay set to: {(int)delayMs} ms", true);
         }
 
-        public async Task<List<DeviceDto>> GetDevices()
+        public async Task<List<DeviceDto>> GetDevices(bool onlyVisible)
         {
-            var devices = await _deviceRepository.GetDevices(new GetDevicesModel() { Ids = _userService.IsAdmin ? null : _userService.GetDevices() });
+            var devices = await _deviceRepository.GetDevices(new GetDevicesModel() { Ids = _userService.IsAdmin ? null : _userService.GetDevices(), OnlyVisible = true });
             return _mapper.Map<List<DeviceDto>>(devices);
         }
 

--- a/src/EnvironmentMonitor.Domain/Entities/Device.cs
+++ b/src/EnvironmentMonitor.Domain/Entities/Device.cs
@@ -9,6 +9,7 @@ namespace EnvironmentMonitor.Domain.Entities
     public class Device
     {
         public int Id { get; set; }
+        public Guid Identifier { get; set; }
         public required string DeviceIdentifier { get; set; }
         public string Name { get; set; }
         public ICollection<Sensor> Sensors { get; set; }

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -14,12 +14,9 @@ namespace EnvironmentMonitor.Domain.Interfaces
     {
         Task<Device?> GetDeviceByIdentifier(string deviceId);
 
-        Task<List<Device>> GetDevices(List<int>? ids = null, bool onlyVisible = true);
-        Task<List<Device>> GetDevices(List<string>? identifiers = null, bool onlyVisible = true);
-        Task<List<Device>> GetDevicesByLocation(List<int> locationIds);
+        Task<List<Device>> GetDevices(GetDeviceModel model);
 
-        Task<List<DeviceInfo>> GetDeviceInfo(List<int>? ids, bool onlyVisible, bool getAttachments = false);
-        Task<List<DeviceInfo>> GetDeviceInfo(List<string>? identifiers, bool onlyVisible, bool getAttachments = false);
+        Task<List<DeviceInfo>> GetDeviceInfo(GetDeviceModel model);
 
         Task<Attachment> GetAttachment(int deviceId, Guid attachmentIdentifier);
 

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -12,7 +12,6 @@ namespace EnvironmentMonitor.Domain.Interfaces
 {
     public interface IDeviceRepository
     {
-        Task<Device?> GetDeviceByIdentifier(string deviceId);
 
         Task<List<Device>> GetDevices(GetDeviceModel model);
 
@@ -21,7 +20,6 @@ namespace EnvironmentMonitor.Domain.Interfaces
         Task<Attachment> GetAttachment(int deviceId, Guid attachmentIdentifier);
 
         Task<List<DeviceEvent>> GetDeviceEvents(int id);
-        Task<List<DeviceEvent>> GetDeviceEvents(string deviceIdentifier);
 
         Task<IEnumerable<Sensor>> GetSensors(GetDeviceModel model);
 

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -13,15 +13,15 @@ namespace EnvironmentMonitor.Domain.Interfaces
     public interface IDeviceRepository
     {
 
-        Task<List<Device>> GetDevices(GetDeviceModel model);
+        Task<List<Device>> GetDevices(GetDevicesModel model);
 
-        Task<List<DeviceInfo>> GetDeviceInfo(GetDeviceModel model);
+        Task<List<DeviceInfo>> GetDeviceInfo(GetDevicesModel model);
 
         Task<Attachment> GetAttachment(int deviceId, Guid attachmentIdentifier);
 
         Task<List<DeviceEvent>> GetDeviceEvents(int id);
 
-        Task<IEnumerable<Sensor>> GetSensors(GetDeviceModel model);
+        Task<IEnumerable<Sensor>> GetSensors(GetDevicesModel model);
 
         public Task<Sensor?> GetSensor(int deviceId, int sensorIdInternal);
 

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -23,8 +23,8 @@ namespace EnvironmentMonitor.Domain.Interfaces
         Task<List<DeviceEvent>> GetDeviceEvents(int id);
         Task<List<DeviceEvent>> GetDeviceEvents(string deviceIdentifier);
 
-        Task<IEnumerable<Sensor>> GetSensorsByDeviceIdsAsync(List<int> deviceId);
-        Task<IEnumerable<Sensor>> GetSensorsByDeviceIdentifiers(List<string> deviceIdentifiers);
+        Task<IEnumerable<Sensor>> GetSensors(GetDeviceModel model);
+
         public Task<Sensor?> GetSensor(int deviceId, int sensorIdInternal);
 
         public Task<DeviceEvent> AddEvent(int deviceId, DeviceEventTypes type, string message, bool saveChanges, DateTime? datetimeUtc);

--- a/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IDeviceRepository.cs
@@ -21,9 +21,7 @@ namespace EnvironmentMonitor.Domain.Interfaces
 
         Task<List<DeviceEvent>> GetDeviceEvents(int id);
 
-        Task<IEnumerable<Sensor>> GetSensors(GetDevicesModel model);
-
-        public Task<Sensor?> GetSensor(int deviceId, int sensorIdInternal);
+        Task<IEnumerable<Sensor>> GetSensors(GetSensorsModel model);
 
         public Task<DeviceEvent> AddEvent(int deviceId, DeviceEventTypes type, string message, bool saveChanges, DateTime? datetimeUtc);
         public Task AddAttachment(int deviceId, Attachment attachment, bool saveChanges);

--- a/src/EnvironmentMonitor.Domain/Models/GetDeviceModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetDeviceModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnvironmentMonitor.Domain.Models
+{
+    public class GetDeviceModel
+    {
+        public List<int>? Ids { get; set; }
+        public List<string>? DeviceIdentifiers { get; set; }
+        public List<Guid>? Identifiers { get; set; }
+        public List<int>? LocationIds { get; set; }
+        public bool OnlyVisible { get; set; }
+        public bool GetAttachments { get; set; }
+    }
+}

--- a/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 namespace EnvironmentMonitor.Domain.Models
 {
+
+
     public class GetDevicesModel
     {
         public List<int>? Ids { get; set; }
@@ -14,5 +16,12 @@ namespace EnvironmentMonitor.Domain.Models
         public List<int>? LocationIds { get; set; }
         public bool OnlyVisible { get; set; }
         public bool GetAttachments { get; set; }
+    }
+
+    public class GetSensorsModel
+    {
+        public required GetDevicesModel DevicesModel { get; set; }
+        public List<int>? Ids { get; set; }
+        public List<int>? SensorIds { get; set; }
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
@@ -16,6 +16,7 @@ namespace EnvironmentMonitor.Domain.Models
         public List<int>? LocationIds { get; set; }
         public bool OnlyVisible { get; set; }
         public bool GetAttachments { get; set; }
+        public bool GetLocation { get; set; }
     }
 
     public class GetSensorsModel

--- a/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetDevicesModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace EnvironmentMonitor.Domain.Models
 {
-    public class GetDeviceModel
+    public class GetDevicesModel
     {
         public List<int>? Ids { get; set; }
         public List<string>? DeviceIdentifiers { get; set; }

--- a/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
@@ -8,7 +8,7 @@ namespace EnvironmentMonitor.Domain.Models
 {
     public class MessageDeviceModel
     {
-        public required string DeviceIdentifier { get; set; }
+        public required Guid DeviceIdentifier { get; set; }
     }
 
     public class SetMotionControlStatusMessage : MessageDeviceModel

--- a/src/EnvironmentMonitor.HubObserver/Functions/HubObserver.cs
+++ b/src/EnvironmentMonitor.HubObserver/Functions/HubObserver.cs
@@ -77,7 +77,6 @@ namespace EnvironmentMonitor.HubObserver.Functions
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Adding measurements failed");
-                    throw;
                 }
             }
             _logger.LogInformation($"Total of {processedMessaged} processed");

--- a/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceConfiguration.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceConfiguration.cs
@@ -26,6 +26,9 @@ namespace EnvironmentMonitor.Infrastructure.Data.Configurations
 
             builder.Property(x => x.Visible).HasDefaultValue(true);
 
+            builder.Property(x => x.Identifier).HasDefaultValueSql("NEWID()");
+            builder.Property(x => x.Identifier).IsRequired();
+
             builder.HasMany(d => d.Sensors)
                 .WithOne(s => s.Device)
                 .HasForeignKey(s => s.DeviceId)

--- a/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceConfiguration.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Configurations/DeviceConfiguration.cs
@@ -22,7 +22,7 @@ namespace EnvironmentMonitor.Infrastructure.Data.Configurations
             builder.Property(x => x.DeviceIdentifier).IsRequired();
             builder.HasIndex(x => x.DeviceIdentifier).IsUnique();
 
-            builder.HasIndex(d => d.Name).IsUnique();
+            builder.HasIndex(d => new { d.Name, d.LocationId }).IsUnique();
 
             builder.Property(x => x.Visible).HasDefaultValue(true);
 

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -280,6 +280,12 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 query = query.Where(x => model.DeviceIdentifiers.Contains(x.DeviceIdentifier));
             }
+
+            if (model.Identifiers != null)
+            {
+                query = query.Where(x => model.Identifiers.Contains(x.Identifier));
+            }
+
             if (model.OnlyVisible)
             {
                 query = query.Where(x => x.Visible);

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -26,25 +26,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
 
         public async Task<List<Device>> GetDevices(GetDevicesModel model)
         {
-            IQueryable<Device> query = _context.Devices;
-            if (model.Identifiers != null)
-            {
-                query = query.Where(x => model.Identifiers.Contains(x.Identifier));
-            }
-            if (model.Ids != null)
-            {
-                query = query.Where(x => model.Ids.Contains(x.Id));
-            }
-
-            if (model.DeviceIdentifiers != null)
-            {
-                query = query.Where(x => model.DeviceIdentifiers.Contains(x.DeviceIdentifier));
-            }
-
-            if (model.OnlyVisible)
-            {
-                query = query.Where(x => x.Visible);
-            }
+            IQueryable<Device> query = GetFilteredDeviceQuery(model);
             var devices = await query.ToListAsync();
             return devices;
         }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -23,10 +23,6 @@ namespace EnvironmentMonitor.Infrastructure.Data
             _dateService = dateService;
             _logger = logger;
         }
-        public async Task<Device?> GetDeviceByIdentifier(string deviceId)
-        {
-            return await _context.Devices.Include(x => x.Sensors).FirstOrDefaultAsync(x => x.DeviceIdentifier == deviceId);
-        }
 
         public async Task<List<Device>> GetDevices(GetDeviceModel model)
         {
@@ -95,7 +91,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
 
         public async Task<List<DeviceInfo>> GetDeviceInfo(GetDeviceModel model)
         {
-            IQueryable<Device> query = GetFilteredQuery(model);
+            IQueryable<Device> query = GetFilteredDeviceQuery(model);
             query = query.Include(x => x.Sensors);
             return await GetDeviceInfos(query);
         }
@@ -103,17 +99,6 @@ namespace EnvironmentMonitor.Infrastructure.Data
         public async Task<List<DeviceEvent>> GetDeviceEvents(int id)
         {
             var query = _context.DeviceEvents.Where(x => x.DeviceId == id).OrderByDescending(x => x.TimeStamp).Take(100);
-            return await query.ToListAsync();
-        }
-
-        public async Task<List<DeviceEvent>> GetDeviceEvents(string deviceIdentifier)
-        {
-            var device = await GetDeviceByIdentifier(deviceIdentifier);
-            if (device == null)
-            {
-                return [];
-            }
-            var query = _context.DeviceEvents.Include(x => x.Type).Where(x => x.DeviceId == device.Id).OrderByDescending(x => x.TimeStamp).Take(100);
             return await query.ToListAsync();
         }
 
@@ -330,7 +315,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return toReturn ?? throw new EntityNotFoundException();
         }
 
-        private IQueryable<Device> GetFilteredQuery(GetDeviceModel model)
+        private IQueryable<Device> GetFilteredDeviceQuery(GetDeviceModel model)
         {
             IQueryable<Device> query = _context.Devices;
             if (model.GetAttachments)

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -274,6 +274,12 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 query = query.Include(x => x.Attachments).ThenInclude(a => a.Attachment);
             }
+
+            if (model.GetLocation)
+            {
+                query = query.Include(x => x.Location);
+            }
+
             if (model.Ids != null)
             {
                 query = query.Where(x => model.Ids.Contains(x.Id));
@@ -292,6 +298,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 query = query.Where(x => x.Visible);
             }
+
             if (model.LocationIds != null)
             {
                 query = query.Where(x => model.LocationIds.Contains(x.LocationId));

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -98,7 +98,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
 
         public async Task<List<DeviceEvent>> GetDeviceEvents(int id)
         {
-            var query = _context.DeviceEvents.Where(x => x.DeviceId == id).OrderByDescending(x => x.TimeStamp).Take(100);
+            var query = _context.DeviceEvents.Include(x => x.Type).Where(x => x.DeviceId == id).OrderByDescending(x => x.TimeStamp).Take(100);
             return await query.ToListAsync();
         }
 

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -31,20 +31,22 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return devices;
         }
 
-        public async Task<Sensor?> GetSensor(int deviceId, int sensorIdInternal)
+        public async Task<IEnumerable<Sensor>> GetSensors(GetSensorsModel model)
         {
-            var sensor = await _context.Sensors.FirstOrDefaultAsync(x => x.DeviceId == deviceId && x.SensorId == sensorIdInternal);
-            return sensor;
-        }
-
-        public async Task<IEnumerable<Sensor>> GetSensors(GetDevicesModel model)
-        {
-            var sensors = await _context.Sensors.Where(x =>
-                (model.DeviceIdentifiers == null || model.DeviceIdentifiers.Contains(x.Device.DeviceIdentifier))
-                && (model.Ids == null || model.Ids.Contains(x.Device.Id))
-                && (model.Identifiers == null || model.Identifiers.Contains(x.Device.Identifier))
-                ).ToListAsync();
-            return sensors;
+            var query = _context.Sensors.Where(x =>
+                (model.DevicesModel.DeviceIdentifiers == null || model.DevicesModel.DeviceIdentifiers.Contains(x.Device.DeviceIdentifier))
+                && (model.DevicesModel.Ids == null || model.DevicesModel.Ids.Contains(x.Device.Id))
+                && (model.DevicesModel.Identifiers == null || model.DevicesModel.Identifiers.Contains(x.Device.Identifier))
+                );
+            if (model.Ids != null)
+            {
+                query = query.Where(x => model.Ids.Contains(x.Id));
+            }
+            if (model.SensorIds != null)
+            {
+                query = query.Where(x => model.SensorIds.Contains(x.SensorId));
+            }
+            return await query.ToListAsync();
         }
 
         public async Task<DeviceEvent> AddEvent(int deviceId, DeviceEventTypes type, string message, bool saveChanges, DateTime? dateTimeUtc)

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -59,15 +59,13 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return sensor;
         }
 
-        public async Task<IEnumerable<Sensor>> GetSensorsByDeviceIdsAsync(List<int> deviceIds)
+        public async Task<IEnumerable<Sensor>> GetSensors(GetDeviceModel model)
         {
-            var sensors = await _context.Sensors.Where(x => deviceIds.Contains(x.DeviceId)).ToListAsync();
-            return sensors;
-        }
-
-        public async Task<IEnumerable<Sensor>> GetSensorsByDeviceIdentifiers(List<string> deviceIdentifiers)
-        {
-            var sensors = await _context.Sensors.Where(x => deviceIdentifiers.Contains(x.Device.DeviceIdentifier)).ToListAsync();
+            var sensors = await _context.Sensors.Where(x =>
+                (model.DeviceIdentifiers == null || model.DeviceIdentifiers.Contains(x.Device.DeviceIdentifier))
+                && (model.Ids == null || model.Ids.Contains(x.Device.Id))
+                && (model.Identifiers == null || model.Identifiers.Contains(x.Device.Identifier))
+                ).ToListAsync();
             return sensors;
         }
 

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -24,7 +24,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             _logger = logger;
         }
 
-        public async Task<List<Device>> GetDevices(GetDeviceModel model)
+        public async Task<List<Device>> GetDevices(GetDevicesModel model)
         {
             IQueryable<Device> query = _context.Devices;
             if (model.Identifiers != null)
@@ -55,7 +55,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return sensor;
         }
 
-        public async Task<IEnumerable<Sensor>> GetSensors(GetDeviceModel model)
+        public async Task<IEnumerable<Sensor>> GetSensors(GetDevicesModel model)
         {
             var sensors = await _context.Sensors.Where(x =>
                 (model.DeviceIdentifiers == null || model.DeviceIdentifiers.Contains(x.Device.DeviceIdentifier))
@@ -89,7 +89,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return toAdd;
         }
 
-        public async Task<List<DeviceInfo>> GetDeviceInfo(GetDeviceModel model)
+        public async Task<List<DeviceInfo>> GetDeviceInfo(GetDevicesModel model)
         {
             IQueryable<Device> query = GetFilteredDeviceQuery(model);
             query = query.Include(x => x.Sensors);
@@ -305,7 +305,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 await _context.SaveChangesAsync();
             }
-            var toReturn = (await GetDeviceInfo(new GetDeviceModel()
+            var toReturn = (await GetDeviceInfo(new GetDevicesModel()
             {
                 Ids = [deviceToUpdate.Id],
                 GetAttachments = true,
@@ -315,7 +315,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             return toReturn ?? throw new EntityNotFoundException();
         }
 
-        private IQueryable<Device> GetFilteredDeviceQuery(GetDeviceModel model)
+        private IQueryable<Device> GetFilteredDeviceQuery(GetDevicesModel model)
         {
             IQueryable<Device> query = _context.Devices;
             if (model.GetAttachments)

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517083123_AddGuidIdentifierToDevices.Designer.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517083123_AddGuidIdentifierToDevices.Designer.cs
@@ -4,6 +4,7 @@ using EnvironmentMonitor.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnvironmentMonitor.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(MeasurementDbContext))]
-    partial class MeasurementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250517083123_AddGuidIdentifierToDevices")]
+    partial class AddGuidIdentifierToDevices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517083123_AddGuidIdentifierToDevices.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517083123_AddGuidIdentifierToDevices.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnvironmentMonitor.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGuidIdentifierToDevices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "Identifier",
+                table: "Devices",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValueSql: "NEWID()");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Identifier",
+                table: "Devices");
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517164704_ChangeDeviceNameIndex.Designer.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517164704_ChangeDeviceNameIndex.Designer.cs
@@ -4,6 +4,7 @@ using EnvironmentMonitor.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnvironmentMonitor.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(MeasurementDbContext))]
-    partial class MeasurementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250517164704_ChangeDeviceNameIndex")]
+    partial class ChangeDeviceNameIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517164704_ChangeDeviceNameIndex.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20250517164704_ChangeDeviceNameIndex.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnvironmentMonitor.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeDeviceNameIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Devices_Name",
+                table: "Devices");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_Name_LocationId",
+                table: "Devices",
+                columns: new[] { "Name", "LocationId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Devices_Name_LocationId",
+                table: "Devices");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_Name",
+                table: "Devices",
+                column: "Name",
+                unique: true);
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
@@ -136,7 +136,7 @@ namespace EnvironmentMonitor.Infrastructure.Services
             var existingSensorIdsInClaims = claims.Where(x => x.Type == EntityRoles.Sensor.ToString()).Select(x => int.Parse(x.Value)).ToList();
 
             var deviceIdsAsClaims = claims.Where(x => x.Type == EntityRoles.Device.ToString()).Select(x => int.Parse(x.Value)).ToList();
-            var deviceIdsMatchingsLocations = (await _deviceRepository.GetDevicesByLocation(locationIdsAsClaims)).Select(x => x.Id).ToList();
+            var deviceIdsMatchingsLocations = (await _deviceRepository.GetDevices(new GetDeviceModel() { LocationIds = locationIdsAsClaims })).Select(x => x.Id).ToList();
 
             var deviceIds = new List<int>(deviceIdsAsClaims);
             deviceIds.AddRange(deviceIdsMatchingsLocations);

--- a/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
@@ -136,13 +136,13 @@ namespace EnvironmentMonitor.Infrastructure.Services
             var existingSensorIdsInClaims = claims.Where(x => x.Type == EntityRoles.Sensor.ToString()).Select(x => int.Parse(x.Value)).ToList();
 
             var deviceIdsAsClaims = claims.Where(x => x.Type == EntityRoles.Device.ToString()).Select(x => int.Parse(x.Value)).ToList();
-            var deviceIdsMatchingsLocations = (await _deviceRepository.GetDevices(new GetDeviceModel() { LocationIds = locationIdsAsClaims })).Select(x => x.Id).ToList();
+            var deviceIdsMatchingsLocations = (await _deviceRepository.GetDevices(new GetDevicesModel() { LocationIds = locationIdsAsClaims })).Select(x => x.Id).ToList();
 
             var deviceIds = new List<int>(deviceIdsAsClaims);
             deviceIds.AddRange(deviceIdsMatchingsLocations);
 
             var claimsToReturn = new List<Claim>();
-            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensors(new GetDeviceModel()
+            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensors(new GetDevicesModel()
             {
                 Ids = deviceIds
             })).Select(x => x.Id).ToList();

--- a/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
@@ -142,7 +142,10 @@ namespace EnvironmentMonitor.Infrastructure.Services
             deviceIds.AddRange(deviceIdsMatchingsLocations);
 
             var claimsToReturn = new List<Claim>();
-            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensorsByDeviceIdsAsync(deviceIds)).Select(x => x.Id).ToList();
+            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensors(new GetDeviceModel()
+            {
+                Ids = deviceIds
+            })).Select(x => x.Id).ToList();
 
             claimsToReturn.AddRange(sensorIdsMatchingDevices
                 .Where(x => !existingSensorIdsInClaims.Contains(x))

--- a/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Services/UserAuthService.cs
@@ -142,9 +142,12 @@ namespace EnvironmentMonitor.Infrastructure.Services
             deviceIds.AddRange(deviceIdsMatchingsLocations);
 
             var claimsToReturn = new List<Claim>();
-            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensors(new GetDevicesModel()
+            var sensorIdsMatchingDevices = (await _deviceRepository.GetSensors(new GetSensorsModel()
             {
-                Ids = deviceIds
+                DevicesModel = new GetDevicesModel()
+                {
+                    Ids = deviceIds
+                }
             })).Select(x => x.Id).ToList();
 
             claimsToReturn.AddRange(sensorIdsMatchingDevices

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceImage.tsx
@@ -108,7 +108,7 @@ export const DeviceImage: React.FC<DeviceImageProps> = ({
       return "";
     }
 
-    return `/api/devices/attachment/${device?.device.deviceIdentifier}/${activeAttachment.guid}`;
+    return `/api/devices/attachment/${device?.device.identifier}/${activeAttachment.guid}`;
   };
 
   return !device ? (

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -7,6 +7,7 @@ import { DataGrid, type GridColDef } from "@mui/x-data-grid";
 import { CheckCircle, Photo, WarningAmber } from "@mui/icons-material";
 import { useState } from "react";
 import { DeviceImageDialog } from "./DeviceImageDialog";
+import { getDeviceTitle } from "../utilities/deviceUtils";
 
 export interface DeviceTableProps {
   devices: DeviceInfo[];
@@ -70,9 +71,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       flex: 1,
       minWidth: 200,
       renderCell: (params) => {
-        const text =
-          (params?.row as DeviceInfo)?.device.displayName ??
-          (params?.row as DeviceInfo)?.device.name;
+        const text = getDeviceTitle((params?.row as DeviceInfo).device);
         return renderLink ? (
           <Link
             to={`${routes.devices}/${

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -45,7 +45,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       renderCell: (params) => (
         <Link
           to={`${routes.devices}/${
-            (params?.row as DeviceInfo)?.device.deviceIdentifier
+            (params?.row as DeviceInfo)?.device.identifier
           }`}
         >
           {(params?.row as DeviceInfo)?.device.id}
@@ -67,7 +67,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       renderCell: (params) => (
         <Link
           to={`${routes.devices}/${
-            (params?.row as DeviceInfo)?.device.deviceIdentifier
+            (params?.row as DeviceInfo)?.device.identifier
           }`}
           onClick={() => {}}
         >
@@ -92,11 +92,11 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
         if (!device.defaultImageGuid) {
           return null;
         }
-        const imageUrl = `/api/Devices/default-image/${device.device.deviceIdentifier}`;
+        const imageUrl = `/api/Devices/default-image/${device.device.identifier}`;
         const iconButtonToRender = (
           <IconButton
             onClick={() => {
-              setSelectedDeviceIdentifier(device.device.deviceIdentifier);
+              setSelectedDeviceIdentifier(device.device.identifier);
             }}
           >
             <Photo />
@@ -247,9 +247,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
 
   const selectedDevice =
     selectedDeviceIdentifier !== undefined
-      ? devices.find(
-          (d) => d.device.deviceIdentifier === selectedDeviceIdentifier
-        )
+      ? devices.find((d) => d.device.identifier === selectedDeviceIdentifier)
       : undefined;
 
   return (

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -17,6 +17,7 @@ export interface DeviceTableProps {
   showDeviceImageAsTooltip?: boolean;
   hideName?: boolean;
   hideId?: boolean;
+  renderLink?: boolean;
 }
 
 export const DeviceTable: React.FC<DeviceTableProps> = ({
@@ -26,6 +27,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
   hideName,
   hideId,
   showDeviceImageAsTooltip,
+  renderLink,
   onClickVisible,
 }) => {
   const formatDate = (input: Date | undefined | null) => {
@@ -42,15 +44,18 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       hideable: true,
       flex: 1,
       maxWidth: 70,
-      renderCell: (params) => (
-        <Link
-          to={`${routes.devices}/${
-            (params?.row as DeviceInfo)?.device.identifier
-          }`}
-        >
-          {(params?.row as DeviceInfo)?.device.id}
-        </Link>
-      ),
+      renderCell: (params) =>
+        renderLink ? (
+          <Link
+            to={`${routes.devices}/${
+              (params?.row as DeviceInfo)?.device.identifier
+            }`}
+          >
+            {(params?.row as DeviceInfo)?.device.id}
+          </Link>
+        ) : (
+          (params?.row as DeviceInfo)?.device.id
+        ),
       valueGetter: (_value, row) => {
         if (!row) {
           return "";
@@ -64,16 +69,19 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       hideable: true,
       flex: 1,
       minWidth: 200,
-      renderCell: (params) => (
-        <Link
-          to={`${routes.devices}/${
-            (params?.row as DeviceInfo)?.device.identifier
-          }`}
-          onClick={() => {}}
-        >
-          {(params?.row as DeviceInfo)?.device.name}
-        </Link>
-      ),
+      renderCell: (params) =>
+        renderLink ? (
+          <Link
+            to={`${routes.devices}/${
+              (params?.row as DeviceInfo)?.device.identifier
+            }`}
+            onClick={() => {}}
+          >
+            {(params?.row as DeviceInfo)?.device.name}
+          </Link>
+        ) : (
+          (params?.row as DeviceInfo)?.device.name
+        ),
       valueGetter: (_value, row) => {
         if (!row) {
           return "";
@@ -291,8 +299,8 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
               columnVisibilityModel:
                 hideName || hideId
                   ? {
-                      name: hideName ?? false,
-                      id: hideId ?? false,
+                      name: hideName ? false : true,
+                      id: hideId ? false : true,
                     }
                   : undefined,
             },

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -85,6 +85,12 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           text
         );
       },
+      valueGetter: (_value, row) => {
+        if (!row) {
+          return "";
+        }
+        return getDeviceTitle((row as DeviceInfo)?.device);
+      },
     },
     {
       field: "image",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -69,24 +69,22 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       hideable: true,
       flex: 1,
       minWidth: 200,
-      renderCell: (params) =>
-        renderLink ? (
+      renderCell: (params) => {
+        const text =
+          (params?.row as DeviceInfo)?.device.displayName ??
+          (params?.row as DeviceInfo)?.device.name;
+        return renderLink ? (
           <Link
             to={`${routes.devices}/${
               (params?.row as DeviceInfo)?.device.identifier
             }`}
             onClick={() => {}}
           >
-            {(params?.row as DeviceInfo)?.device.name}
+            {text}
           </Link>
         ) : (
-          (params?.row as DeviceInfo)?.device.name
-        ),
-      valueGetter: (_value, row) => {
-        if (!row) {
-          return "";
-        }
-        return (row as DeviceInfo)?.device.name;
+          text
+        );
       },
     },
     {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsInfoTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsInfoTable.tsx
@@ -41,7 +41,11 @@ export const MeasurementsInfoTable: React.FC<MeasurementsInfoTableProps> = ({
     if (!row.device) {
       return null;
     }
-    return <TableCell>{`${row.device.name}`}</TableCell>;
+    return (
+      <TableCell>
+        {row.device.displayName ? row.device.displayName : `${row.device.name}`}
+      </TableCell>
+    );
   };
 
   const hasDevices = () => {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
@@ -107,7 +107,7 @@ export const MeasurementsLeftView: React.FC<MeasurementsLeftViewProps> = ({
             value={
               selectedDevices
                 ? selectedDevices.map((s) => {
-                    return s.deviceIdentifier;
+                    return s.identifier;
                   })
                 : []
             }
@@ -116,10 +116,10 @@ export const MeasurementsLeftView: React.FC<MeasurementsLeftViewProps> = ({
           >
             {devices.map((y) => (
               <MenuItem
-                value={y.deviceIdentifier}
-                key={`device-${y.deviceIdentifier}`}
+                value={y.identifier}
+                key={`device-${y.identifier}`}
                 onClick={() => {
-                  onSelectDevice(y.deviceIdentifier);
+                  onSelectDevice(y.identifier);
                 }}
               >
                 {y.name}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
@@ -12,6 +12,7 @@ import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
 import { type Device } from "../models/device";
 import { type Sensor } from "../models/sensor";
 import { stringSort } from "../utilities/stringUtils";
+import { getDeviceTitle } from "../utilities/deviceUtils";
 
 export interface MeasurementsLeftViewProps {
   onSearch: (
@@ -116,17 +117,19 @@ export const MeasurementsLeftView: React.FC<MeasurementsLeftViewProps> = ({
             label="Device"
             multiple
           >
-            {devices.map((y) => (
-              <MenuItem
-                value={y.identifier}
-                key={`device-${y.identifier}`}
-                onClick={() => {
-                  onSelectDevice(y.identifier);
-                }}
-              >
-                {y.displayName ?? y.name}
-              </MenuItem>
-            ))}
+            {[...devices]
+              .sort((a, b) => stringSort(getDeviceTitle(a), getDeviceTitle(b)))
+              .map((y) => (
+                <MenuItem
+                  value={y.identifier}
+                  key={`device-${y.identifier}`}
+                  onClick={() => {
+                    onSelectDevice(y.identifier);
+                  }}
+                >
+                  {getDeviceTitle(y)}
+                </MenuItem>
+              ))}
           </Select>
         </FormControl>
       </Box>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MeasurementsLeftView.tsx
@@ -58,7 +58,9 @@ export const MeasurementsLeftView: React.FC<MeasurementsLeftViewProps> = ({
   const getSensorText = (sensor: Sensor) => {
     if (selectedDevices && selectedDevices.length > 1) {
       const matchingDevice = devices.find((d) => d.id === sensor.deviceId);
-      return `${matchingDevice?.name}: ${sensor.name}`;
+      return `${matchingDevice?.displayName ?? matchingDevice?.name}: ${
+        sensor.name
+      }`;
     }
     return sensor.name;
   };
@@ -122,7 +124,7 @@ export const MeasurementsLeftView: React.FC<MeasurementsLeftViewProps> = ({
                   onSelectDevice(y.identifier);
                 }}
               >
-                {y.name}
+                {y.displayName ?? y.name}
               </MenuItem>
             ))}
           </Select>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -117,7 +117,9 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
         devices.length > 1 &&
         devices.find((d) => d.id === matchingSensor?.deviceId);
       if (device) {
-        sensorName = `${device.name}: ${sensorName}`;
+        sensorName = device.displayName
+          ? `${device.displayName}: ${sensorName}`
+          : `${device.name}: ${sensorName}`;
       }
 
       return getDatasetLabel(sensorName, typeId as MeasurementTypes);

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -197,6 +197,11 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
         return "";
       }
     }
+
+    if (singleDevice.displayName) {
+      return singleDevice.displayName;
+    }
+
     return `${singleDevice?.name} / (${singleDevice?.id})`;
   };
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -274,7 +274,7 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
         alignItems="center" // Align children vertically
       >
         {titleAsLink ? (
-          <Link to={`${routes.measurements}/${singleDevice?.deviceIdentifier}`}>
+          <Link to={`${routes.measurements}/${singleDevice?.identifier}`}>
             <Typography align="left" gutterBottom>
               {getTitle()}
             </Typography>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -81,6 +81,25 @@ export const DashboardView: React.FC = () => {
     });
   }, [devices, sensors, viewModel]);
 
+  const list = measurementsModel
+    .slice()
+    .sort((a, b) => {
+      const locA = a.device.locationId ?? 0;
+      const locB = b.device.locationId ?? 0;
+      return locA - locB;
+    })
+    .map(({ device, sensors, model }) => {
+      return (
+        <DashboardDeviceGraph
+          device={device}
+          model={model}
+          sensors={sensors}
+          key={device.id}
+          timeRange={timeRange}
+        />
+      );
+    });
+
   return (
     <AppContentWrapper
       title="Dashboard - Devices"
@@ -114,17 +133,7 @@ export const DashboardView: React.FC = () => {
             height: "100%",
           }}
         >
-          {measurementsModel.map(({ device, sensors, model }) => {
-            return (
-              <DashboardDeviceGraph
-                device={device}
-                model={model}
-                sensors={sensors}
-                key={device.id}
-                timeRange={timeRange}
-              />
-            );
-          })}
+          {list}
         </Box>
       </Box>
     </AppContentWrapper>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -224,10 +224,10 @@ export const DeviceView: React.FC = () => {
     }
     setIsLoading(true);
     deviceHook
-      .setMotionControlState(selectedDevice.device.deviceIdentifier, state)
+      .setMotionControlState(selectedDevice.device.identifier, state)
       .then((res) => {
         if (res) {
-          getDeviceEvents(selectedDevice.device.deviceIdentifier);
+          getDeviceEvents(selectedDevice.device.identifier);
           dispatch(
             addNotification({
               title: message ?? "Message sent to device",
@@ -260,10 +260,10 @@ export const DeviceView: React.FC = () => {
     }
     setIsLoading(true);
     deviceHook
-      .setMotionControlDelay(selectedDevice.device.deviceIdentifier, delayMs)
+      .setMotionControlDelay(selectedDevice.device.identifier, delayMs)
       .then((res) => {
         if (res) {
-          getDeviceEvents(selectedDevice.device.deviceIdentifier);
+          getDeviceEvents(selectedDevice.device.identifier);
           dispatch(
             addNotification({
               title: message ?? "Message sent to device",
@@ -294,9 +294,9 @@ export const DeviceView: React.FC = () => {
     }
     setIsLoading(true);
     deviceHook
-      .rebootDevice(selectedDevice?.device.deviceIdentifier)
+      .rebootDevice(selectedDevice?.device.identifier)
       .then(() => {
-        getDeviceEvents(selectedDevice?.device.deviceIdentifier);
+        getDeviceEvents(selectedDevice?.device.identifier);
         dispatch(
           addNotification({
             title: message ?? "Message sent to device",
@@ -326,7 +326,7 @@ export const DeviceView: React.FC = () => {
     setIsLoading(true);
 
     deviceHook
-      .uploadImage(selectedDevice?.device.deviceIdentifier, file)
+      .uploadImage(selectedDevice?.device.identifier, file)
       .then((res) => {
         setSelectedDevice(res);
         setDefaultImageVer(defaultImageVer + 1);
@@ -353,7 +353,7 @@ export const DeviceView: React.FC = () => {
     setIsLoading(true);
 
     deviceHook
-      .deleteAttachment(selectedDevice.device.deviceIdentifier, identifier)
+      .deleteAttachment(selectedDevice.device.identifier, identifier)
       .then((res) => {
         setSelectedDevice(res);
         dispatch(
@@ -380,7 +380,7 @@ export const DeviceView: React.FC = () => {
     setIsLoading(true);
 
     deviceHook
-      .setDefaultImage(selectedDevice?.device.deviceIdentifier, identifier)
+      .setDefaultImage(selectedDevice?.device.identifier, identifier)
       .then((res) => {
         setSelectedDevice(res);
         dispatch(

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -22,6 +22,7 @@ import { type MeasurementsViewModel } from "../models/measurementsBySensor";
 import { type DeviceStatusModel } from "../models/deviceStatus";
 import { MeasurementTypes } from "../enums/measurementTypes";
 import { setDevices } from "../reducers/measurementReducer";
+import { getDeviceTitle } from "../utilities/deviceUtils";
 
 interface PromiseInfo {
   type: string;
@@ -413,7 +414,7 @@ export const DeviceView: React.FC = () => {
 
   return (
     <AppContentWrapper
-      title={`${selectedDevice?.device?.name ?? ""}`}
+      title={getDeviceTitle(selectedDevice?.device)}
       isLoading={isLoading}
     >
       <Box

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -21,6 +21,7 @@ import moment from "moment";
 import { type MeasurementsViewModel } from "../models/measurementsBySensor";
 import { type DeviceStatusModel } from "../models/deviceStatus";
 import { MeasurementTypes } from "../enums/measurementTypes";
+import { setDevices } from "../reducers/measurementReducer";
 
 interface PromiseInfo {
   type: string;
@@ -209,6 +210,17 @@ export const DeviceView: React.FC = () => {
             severity: "success",
           })
         );
+        // Update devices
+        measurementApiHook
+          .getDevices()
+          .then((res) => {
+            if (res) {
+              dispatch(setDevices(res));
+            }
+          })
+          .catch((ex) => {
+            console.error(ex);
+          });
       })
       .catch((er) => {
         console.error(er);

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DevicesView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DevicesView.tsx
@@ -47,7 +47,7 @@ export const DevicesView: React.FC = () => {
       return;
     }
     setIsLoading(true);
-    const deviceIdentifier = device.deviceIdentifier;
+    const deviceIdentifier = device.identifier;
 
     deviceHook
       .rebootDevice(deviceIdentifier)
@@ -100,7 +100,7 @@ export const DevicesView: React.FC = () => {
                 rebootDevice(device.device);
               },
               title: `Reboot ${device.device.name}?`,
-              body: `Reboot command will be sent to ${device.device.name}.  Id: ${device.device.id}, Identifier: '${device.device.deviceIdentifier}'`,
+              body: `Reboot command will be sent to ${device.device.name}.  Id: ${device.device.id}, Identifier: '${device.device.identifier}'`,
             })
           );
         }}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DevicesView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DevicesView.tsx
@@ -93,6 +93,7 @@ export const DevicesView: React.FC = () => {
     <AppContentWrapper title="Devices" isLoading={isLoading}>
       <DeviceTable
         devices={sorted}
+        renderLink
         onReboot={(device) => {
           dispatch(
             setConfirmDialog({

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/MeasurementsView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/MeasurementsView.tsx
@@ -53,9 +53,9 @@ export const MeasurementsView: React.FC = () => {
   };
 
   const toggleDeviceSelection = (deviceId: string) => {
-    const matchingDevice = devices.find((d) => d.deviceIdentifier === deviceId);
+    const matchingDevice = devices.find((d) => d.identifier === deviceId);
 
-    if (!selectedDevices.some((s) => s.deviceIdentifier === deviceId)) {
+    if (!selectedDevices.some((s) => s.identifier === deviceId)) {
       if (matchingDevice) {
         setSelectedDevices([...selectedDevices, matchingDevice]);
       }
@@ -64,16 +64,14 @@ export const MeasurementsView: React.FC = () => {
         selectedSensors.filter((s) => s.deviceId !== matchingDevice?.id)
       );
       setSelectedDevices(
-        selectedDevices.filter((s) => s.deviceIdentifier !== deviceId)
+        selectedDevices.filter((s) => s.identifier !== deviceId)
       );
     }
   };
 
   useEffect(() => {
     if (deviceId !== undefined && devices.length > 0) {
-      const matchingDevice = devices.find(
-        (d) => d.deviceIdentifier === deviceId
-      );
+      const matchingDevice = devices.find((d) => d.identifier === deviceId);
       if (matchingDevice) {
         setSelectedDevices([matchingDevice]);
         const sensorIds = sensors

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/framework/App.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/framework/App.tsx
@@ -109,7 +109,7 @@ export const App: React.FC<AppProps> = (props) => {
       dispath(setSensors([]));
     } else {
       measurementApiHook
-        .getSensors(devices.map((x) => x.deviceIdentifier))
+        .getSensors(devices.map((x) => x.identifier))
         .then((res) => {
           dispath(setSensors(res));
         });

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
@@ -7,4 +7,5 @@ export interface Device {
   visible: boolean;
   hasMotionSensor: boolean;
   sensors: Sensor[];
+  locationId?: number;
 }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
@@ -1,7 +1,7 @@
 import type { Sensor } from "./sensor";
 
 export interface Device {
-  deviceIdentifier: string;
+  identifier: string;
   id: number;
   name: string;
   visible: boolean;

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/device.ts
@@ -8,4 +8,5 @@ export interface Device {
   hasMotionSensor: boolean;
   sensors: Sensor[];
   locationId?: number;
+  displayName?: string;
 }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/utilities/deviceUtils.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/utilities/deviceUtils.ts
@@ -1,0 +1,8 @@
+import type { Device } from "../models/device";
+
+export const getDeviceTitle = (device: Device | undefined): string => {
+  if (!device) {
+    return "";
+  }
+  return device.displayName ?? device.name;
+};

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -105,7 +105,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [HttpGet]
         public async Task<List<DeviceDto>> GetDevices()
         {
-            var result = await _deviceService.GetDevices();
+            var result = await _deviceService.GetDevices(true);
             return result;
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -121,7 +121,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [Authorize(Roles = "Admin")]
         public async Task<DeviceInfoDto> GetDeviceInfo(Guid identifier)
         {
-            var result = await _deviceService.GetDeviceInfos(false, [identifier], true);
+            var result = await _deviceService.GetDeviceInfos(false, [identifier], true, true);
             return result.First();
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -105,7 +105,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [HttpGet]
         public async Task<List<DeviceDto>> GetDevices()
         {
-            var result = await _deviceService.GetDevices(true);
+            var result = await _deviceService.GetDevices(true, true);
             return result;
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -33,7 +33,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         }
 
         [HttpPut("update")]
-        public async Task<DeviceInfoDto> Reboot([FromBody] UpdateDeviceDto model) => await _deviceService.UpdateDevice(model);
+        public async Task<DeviceInfoDto> Update([FromBody] UpdateDeviceDto model) => await _deviceService.UpdateDevice(model);
 
         [HttpPost("reboot")]
         [Authorize(Roles = "Admin")]

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -113,7 +113,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [Authorize(Roles = "Admin")]
         public async Task<List<DeviceInfoDto>> GetDeviceInfos()
         {
-            var result = await _deviceService.GetDeviceInfos(false, null); 
+            var result = await _deviceService.GetDeviceInfos(false, null, false, true);
             return result;
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -103,19 +103,11 @@ namespace EnvironmentMonitor.WebApi.Controllers
         }
 
         [HttpGet]
-        public async Task<List<DeviceDto>> GetDevices()
-        {
-            var result = await _deviceService.GetDevices(true, true);
-            return result;
-        }
+        public async Task<List<DeviceDto>> GetDevices() => await _deviceService.GetDevices(true, true);
 
         [HttpGet(template: "info")]
         [Authorize(Roles = "Admin")]
-        public async Task<List<DeviceInfoDto>> GetDeviceInfos()
-        {
-            var result = await _deviceService.GetDeviceInfos(false, null, false, true);
-            return result;
-        }
+        public async Task<List<DeviceInfoDto>> GetDeviceInfos() => await _deviceService.GetDeviceInfos(false, null, false, true);
 
         [HttpGet(template: "info/{identifier}")]
         [Authorize(Roles = "Admin")]
@@ -126,28 +118,15 @@ namespace EnvironmentMonitor.WebApi.Controllers
         }
 
         [HttpGet(template: "{identifier}")]
-        public async Task<DeviceDto> GetDevice([FromRoute] string identifier)
-        {
-            return await _deviceService.GetDevice(identifier, AccessLevels.Read);
-        }
+        public async Task<DeviceDto> GetDevice([FromRoute] string identifier) => await _deviceService.GetDevice(identifier, AccessLevels.Read);
 
         [HttpGet(template: "events/{identifier}")]
-        public async Task<List<DeviceEventDto>> GetDeviceEvents([FromRoute] Guid identifier)
-        {
-            return await _deviceService.GetDeviceEvents(identifier);
-        }
+        public async Task<List<DeviceEventDto>> GetDeviceEvents([FromRoute] Guid identifier) => await _deviceService.GetDeviceEvents(identifier);
 
         [HttpGet("sensors")]
-        public async Task<List<SensorDto>> GetSensors([FromQuery] List<Guid> deviceIds)
-        {
-            var result = await _deviceService.GetSensors(deviceIds);
-            return result;
-        }
+        public async Task<List<SensorDto>> GetSensors([FromQuery] List<Guid> deviceIds) => await _deviceService.GetSensors(deviceIds);
 
         [HttpGet("status")]
-        public async Task<DeviceStatusModel> GetDeviceStatus([FromQuery] GetDeviceStatusModel model)
-        {
-            return await _deviceService.GetDeviceStatus(model);
-        }
+        public async Task<DeviceStatusModel> GetDeviceStatus([FromQuery] GetDeviceStatusModel model) => await _deviceService.GetDeviceStatus(model);
     }
 }

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -113,7 +113,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [Authorize(Roles = "Admin")]
         public async Task<List<DeviceInfoDto>> GetDeviceInfos()
         {
-            var result = await _deviceService.GetDeviceInfos(false, null); // Also the ones marked as non-visible
+            var result = await _deviceService.GetDeviceInfos(false, null); 
             return result;
         }
 
@@ -121,7 +121,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [Authorize(Roles = "Admin")]
         public async Task<DeviceInfoDto> GetDeviceInfo(string identifier)
         {
-            var result = await _deviceService.GetDeviceInfos(false, [identifier], true); // Also the ones marked as non-visible
+            var result = await _deviceService.GetDeviceInfos(false, [identifier], true);
             return result.First();
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -49,7 +49,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
 
         [HttpPost("attachment")]
         [Authorize(Roles = "Admin")]
-        public async Task<DeviceInfoDto> UploadAttachment([FromForm] string deviceId, IFormFile file)
+        public async Task<DeviceInfoDto> UploadAttachment([FromForm] Guid deviceId, IFormFile file)
         {
             var maxFileSize = _fileUploadSettings.MaxImageUploadSizeMb * 1024 * 1024;
             if (file == null || file.Length > maxFileSize)
@@ -69,7 +69,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [HttpGet("attachment/{deviceId}/{identifier}")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "image/jpeg")]
         [Authorize(Roles = "Admin")]
-        public async Task<IActionResult> GetAttachment([FromRoute] string deviceId, [FromRoute] Guid identifier)
+        public async Task<IActionResult> GetAttachment([FromRoute] Guid deviceId, [FromRoute] Guid identifier)
         {
             var stream = await _deviceService.GetAttachment(deviceId, identifier);
             return stream == null ? NotFound() : new FileStreamResult(stream.Stream, stream.ContentType);
@@ -78,7 +78,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [HttpGet("default-image/{deviceId}")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "image/jpeg")]
         [Authorize(Roles = "Admin")]
-        public async Task<FileStreamResult?> GetDefaultImage([FromRoute] string deviceId)
+        public async Task<FileStreamResult?> GetDefaultImage([FromRoute] Guid deviceId)
         {
             var stream = await _deviceService.GetDefaultImage(deviceId);
             return stream == null ? null : new FileStreamResult(stream.Stream, stream.ContentType);
@@ -95,7 +95,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
 
         [HttpDelete("attachment/{deviceId}/{attachmentIdentifier}")]
         [Authorize(Roles = "Admin")]
-        public async Task<DeviceInfoDto> DeleteAttachment([FromRoute] string deviceId, [FromRoute] Guid attachmentIdentifier)
+        public async Task<DeviceInfoDto> DeleteAttachment([FromRoute] Guid deviceId, [FromRoute] Guid attachmentIdentifier)
         {
             await _deviceService.DeleteAttachment(deviceId, attachmentIdentifier);
             var deviceInfos = await _deviceService.GetDeviceInfos(false, [deviceId], true);
@@ -119,7 +119,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
 
         [HttpGet(template: "info/{identifier}")]
         [Authorize(Roles = "Admin")]
-        public async Task<DeviceInfoDto> GetDeviceInfo(string identifier)
+        public async Task<DeviceInfoDto> GetDeviceInfo(Guid identifier)
         {
             var result = await _deviceService.GetDeviceInfos(false, [identifier], true);
             return result.First();
@@ -132,13 +132,13 @@ namespace EnvironmentMonitor.WebApi.Controllers
         }
 
         [HttpGet(template: "events/{identifier}")]
-        public async Task<List<DeviceEventDto>> GetDeviceEvents([FromRoute] string identifier)
+        public async Task<List<DeviceEventDto>> GetDeviceEvents([FromRoute] Guid identifier)
         {
             return await _deviceService.GetDeviceEvents(identifier);
         }
 
         [HttpGet("sensors")]
-        public async Task<List<SensorDto>> GetSensors([FromQuery] List<string> deviceIds)
+        public async Task<List<SensorDto>> GetSensors([FromQuery] List<Guid> deviceIds)
         {
             var result = await _deviceService.GetSensors(deviceIds);
             return result;


### PR DESCRIPTION
Changes for interacting with devices
- Instead of ``DeviceIdentifier``, which is a string and used in IoT hub, use guid identifiers for devices in UI / in general when interacting with them.
- ``DeviceIdentifier`` still used when adding measurements.

Refactored ``DeviceRepository`` by creating a class ``GetDevicesModel`` which makes it possible to pass multiple criteria. With this approach, it is possible to have fewer methods. Also refactored the fetching of sensors to reduce methods in ``DeviceRepository``.

Also some other changes, such as:
- Show ID for devices
- Sort devices in dashboard according to location id
- Changed the unique index in Devices table to include locationId and name
- Display name shown for devices (location name - device name)
