### PR TITLE
Fetch graph data one by one in dashboard view

### DIFF
--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
@@ -32,6 +32,7 @@
         "react-cookie": "^7.2.2",
         "react-dom": "^19.1.0",
         "react-dropzone": "^14.3.8",
+        "react-intersection-observer": "^9.16.0",
         "react-redux": "^9.1.2",
         "react-router": "^7.0.1",
         "react-router-dom": "^7.0.1",
@@ -5455,6 +5456,21 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
@@ -34,6 +34,7 @@
     "react-cookie": "^7.2.2",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.3.8",
+    "react-intersection-observer": "^9.16.0",
     "react-redux": "^9.1.2",
     "react-router": "^7.0.1",
     "react-router-dom": "^7.0.1",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
@@ -28,10 +28,15 @@ export const DashboardDeviceGraph: React.FC<{
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (model) {
-      setDeviceModel(undefined);
+    if (!timeRange) {
+      return;
     }
-  }, [model]);
+    if (!sensors || sensors.length === 0) {
+      return;
+    }
+    onRefresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeRange]);
   const dispatch = useDispatch();
 
   const onRefresh = () => {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
@@ -81,6 +81,7 @@ export const DashboardDeviceGraph: React.FC<{
         justifyContent: "center",
         alignItems: "center",
         position: "relative",
+        maxHeight: "600px",
       }}
     >
       <MultiSensorGraph

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardDeviceGraph.tsx
@@ -47,12 +47,12 @@ export const DashboardDeviceGraph: React.FC<{
     if (timeRange === lastRange) {
       return;
     }
-    onRefresh();
+    onFetchMeasurements();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeRange, inView]);
   const dispatch = useDispatch();
 
-  const onRefresh = () => {
+  const onFetchMeasurements = () => {
     if (sensors.length === 0) {
       return;
     }
@@ -109,7 +109,7 @@ export const DashboardDeviceGraph: React.FC<{
         onSetAutoScale={(state) =>
           dispatch(toggleAutoScale({ deviceId: device.id, state }))
         }
-        onRefresh={onRefresh}
+        onRefresh={onFetchMeasurements}
         isLoading={isLoading}
       />
     </Box>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
@@ -25,7 +25,9 @@ export const DashboardLocationGraph: React.FC<{
     if (model) {
       setMeasurementModel(undefined);
     }
-  }, [model]);
+    onRefresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeRange]);
 
   const onRefresh = () => {
     setIsLoading(true);

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
@@ -61,7 +61,7 @@ export const DashboardLocationGraph: React.FC<{
       }}
     >
       <MultiSensorGraph
-        sensors={model?.sensors}
+        sensors={measurementModel?.sensors ?? model?.sensors}
         devices={undefined}
         model={measurementModel ?? model}
         minHeight={400}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DashboardLocationGraph.tsx
@@ -58,6 +58,7 @@ export const DashboardLocationGraph: React.FC<{
         justifyContent: "center",
         alignItems: "center",
         position: "relative",
+        maxHeight: "650px",
       }}
     >
       <MultiSensorGraph

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/TimeRangeSelectorComponent.tsx
@@ -19,10 +19,10 @@ export const TimeRangeSelectorComponent: React.FC<
   };
 
   const handleClose = (value?: number) => {
+    setAnchorEl(null);
     if (value !== undefined) {
       onSelectTimeRange(value);
     }
-    setAnchorEl(null);
   };
 
   return (

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardLocationsView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardLocationsView.tsx
@@ -1,25 +1,17 @@
 import { useDispatch, useSelector } from "react-redux";
 import { AppContentWrapper } from "../framework/AppContentWrapper";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   getDashboardTimeRange,
   getLocations,
   setDashboardTimeRange,
 } from "../reducers/measurementReducer";
-import { useApiHook } from "../hooks/apiHook";
 import { Box } from "@mui/material";
-import moment from "moment";
-import { type MeasurementsByLocationModel } from "../models/measurementsBySensor";
 import { TimeRangeSelectorComponent } from "../components/TimeRangeSelectorComponent";
 import { DashboardLocationGraph } from "../components/DashboardLocationGraph";
 
 export const DashbordLocationsView: React.FC = () => {
-  const measurementApiHook = useApiHook().measureHook;
   const dispatch = useDispatch();
-  const [viewModel, setViewModel] = useState<
-    MeasurementsByLocationModel | undefined
-  >(undefined);
-  const [isLoading, setIsLoading] = useState(false);
 
   const locations = useSelector(getLocations);
 
@@ -29,39 +21,9 @@ export const DashbordLocationsView: React.FC = () => {
     dispatch(setDashboardTimeRange(selection));
   };
 
-  useEffect(() => {
-    if (!locations || locations.length === 0) {
-      console.log("Returning");
-      return;
-    }
-    setIsLoading(true);
-    const momentStart = moment()
-      .local(true)
-      .add(-1 * timeRange, "hour")
-      .utc(true);
-    measurementApiHook
-      .getMeasurementsByLocation(
-        locations.map((l) => l.id),
-        momentStart,
-        undefined
-      )
-      .then((res) => {
-        setViewModel(res); // Set to false once the model is formed
-      })
-      .catch((er) => {
-        console.error(er);
-        setViewModel(undefined);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRange, locations]);
-
   return (
     <AppContentWrapper
       title="Dashboard - Locations"
-      isLoading={isLoading}
       titleComponent={
         <TimeRangeSelectorComponent
           timeRange={timeRange}
@@ -73,7 +35,7 @@ export const DashbordLocationsView: React.FC = () => {
         sx={{
           display: "grid",
           gridTemplateColumns:
-            viewModel?.measurements && viewModel?.measurements.length > 3
+            locations && locations.length > 3
               ? {
                   xs: "1fr",
                   lg: "1fr 1fr",
@@ -85,13 +47,13 @@ export const DashbordLocationsView: React.FC = () => {
           height: "100%",
         }}
       >
-        {viewModel?.measurements.map((m) => {
+        {locations?.map((m) => {
           const location = locations.find((l) => l.id === m.id);
           return (
             <DashboardLocationGraph
               location={location!}
               timeRange={timeRange}
-              model={m}
+              model={undefined}
               key={m.id}
             />
           );

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -1,34 +1,25 @@
 import { useDispatch, useSelector } from "react-redux";
 import { AppContentWrapper } from "../framework/AppContentWrapper";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import {
   getDashboardTimeRange,
   getDevices,
   getSensors,
   setDashboardTimeRange,
 } from "../reducers/measurementReducer";
-import { useApiHook } from "../hooks/apiHook";
 import { Box } from "@mui/material";
-import moment from "moment";
-import { type MeasurementsViewModel } from "../models/measurementsBySensor";
 import { TimeRangeSelectorComponent } from "../components/TimeRangeSelectorComponent";
 import { DashboardDeviceGraph } from "../components/DashboardDeviceGraph";
 import { type Sensor } from "../models/sensor";
 import { type Device } from "../models/device";
 
 interface DeviceDashboardModel {
-  model: MeasurementsViewModel | undefined;
   sensors: Sensor[];
   device: Device;
 }
 
 export const DashboardView: React.FC = () => {
-  const measurementApiHook = useApiHook().measureHook;
   const dispatch = useDispatch();
-  const [viewModel, setViewModel] = useState<MeasurementsViewModel | undefined>(
-    undefined
-  );
-  const [isLoading, setIsLoading] = useState(false);
 
   const sensors = useSelector(getSensors);
   const devices = useSelector(getDevices);
@@ -39,47 +30,13 @@ export const DashboardView: React.FC = () => {
     dispatch(setDashboardTimeRange(selection));
   };
 
-  useEffect(() => {
-    if (!sensors || sensors.length === 0) {
-      return;
-    }
-    const momentStart = moment()
-      .local(true)
-      .add(-1 * timeRange, "hour")
-      .utc(true);
-    setIsLoading(true);
-    measurementApiHook
-      .getMeasurementsBySensor(
-        sensors.map((x) => x.id),
-        momentStart,
-        undefined
-      )
-      .then((res) => {
-        setViewModel(res); // Set to false once the model is formed
-      })
-      .catch((er) => {
-        console.error(er);
-        setViewModel(undefined);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRange]);
-
   const measurementsModel: DeviceDashboardModel[] = useMemo(() => {
     return devices.map((device) => {
       const deviceSensors = sensors.filter((s) => s.deviceId === device.id);
-      const measurementsModel: MeasurementsViewModel | undefined = viewModel
-        ? {
-            measurements: viewModel.measurements.filter((m) =>
-              deviceSensors.some((s) => s.id === m.sensorId)
-            ),
-          }
-        : undefined;
-      return { device, sensors: deviceSensors, model: measurementsModel };
+
+      return { device, sensors: deviceSensors };
     });
-  }, [devices, sensors, viewModel]);
+  }, [devices, sensors]);
 
   const list = measurementsModel
     .slice()
@@ -88,11 +45,11 @@ export const DashboardView: React.FC = () => {
       const locB = b.device.locationId ?? 0;
       return locA - locB;
     })
-    .map(({ device, sensors, model }) => {
+    .map(({ device, sensors }) => {
       return (
         <DashboardDeviceGraph
           device={device}
-          model={model}
+          model={undefined}
           sensors={sensors}
           key={device.id}
           timeRange={timeRange}
@@ -103,7 +60,6 @@ export const DashboardView: React.FC = () => {
   return (
     <AppContentWrapper
       title="Dashboard - Devices"
-      isLoading={isLoading}
       titleComponent={
         <TimeRangeSelectorComponent
           timeRange={timeRange}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DashboardView.tsx
@@ -27,35 +27,36 @@ export const DashboardView: React.FC = () => {
   const timeRange = useSelector(getDashboardTimeRange);
 
   const handleTimeRangeChange = (selection: number) => {
-    dispatch(setDashboardTimeRange(selection));
+    setTimeout(() => {
+      dispatch(setDashboardTimeRange(selection));
+    }, 10);
   };
 
   const measurementsModel: DeviceDashboardModel[] = useMemo(() => {
-    return devices.map((device) => {
-      const deviceSensors = sensors.filter((s) => s.deviceId === device.id);
+    return [...devices]
+      .sort((a, b) => {
+        const locA = a.locationId ?? 0;
+        const locB = b.locationId ?? 0;
+        return locA - locB;
+      })
+      .map((device) => {
+        const deviceSensors = sensors.filter((s) => s.deviceId === device.id);
 
-      return { device, sensors: deviceSensors };
-    });
+        return { device, sensors: deviceSensors };
+      });
   }, [devices, sensors]);
 
-  const list = measurementsModel
-    .slice()
-    .sort((a, b) => {
-      const locA = a.device.locationId ?? 0;
-      const locB = b.device.locationId ?? 0;
-      return locA - locB;
-    })
-    .map(({ device, sensors }) => {
-      return (
-        <DashboardDeviceGraph
-          device={device}
-          model={undefined}
-          sensors={sensors}
-          key={device.id}
-          timeRange={timeRange}
-        />
-      );
-    });
+  const list = measurementsModel.map(({ device, sensors }) => {
+    return (
+      <DashboardDeviceGraph
+        device={device}
+        model={undefined}
+        sensors={sensors}
+        key={device.id}
+        timeRange={timeRange}
+      />
+    );
+  });
 
   return (
     <AppContentWrapper


### PR DESCRIPTION
- Added functionality for fetching graph data one by one in dashboard views
- Used ``react-intersection-observer`` to check when a graph enters the viewport. In update is needed, measurements are fetched at that point.