### PR TITLE
Possibility to show related measurements in a dialog when clicking a dataset labe

### DIFF
--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -536,6 +536,7 @@ export const DeviceView: React.FC = () => {
             highlightPoints
             minHeight={400}
             isLoading={isLoadingDeviceStatus}
+            showMeasurementsOnDatasetClick
             model={
               selectedDevice
                 ? {
@@ -549,7 +550,7 @@ export const DeviceView: React.FC = () => {
                           ? deviceStatusModel.deviceStatuses.map((d) => {
                               return {
                                 sensorId: selectedDevice.device.id,
-                                sensorValue: d.status,
+                                sensorValue: d.status ? 1 : 0,
                                 typeId: MeasurementTypes.Undefined,
                                 timestamp: d.timestamp,
                               };

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceStatus.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceStatus.ts
@@ -1,5 +1,5 @@
 export interface DeviceStatus {
-  status: number;
+  status: boolean;
   deviceId: number;
   timestamp: Date;
 }


### PR DESCRIPTION
- Added possibility for showing the related measurements in ``MeasurementDialog`` when clicking a dataset label in ``MultiSensorGraph``. 
- Whether this happens or dataset visibility is toggled is controlled through a prop.