### PR TITLE
Package updates, fix repeating colors for MultiSensorGraph

### DIFF
--- a/src/EnvironmentMonitor.Infrastructure/EnvironmentMonitor.Infrastructure.csproj
+++ b/src/EnvironmentMonitor.Infrastructure/EnvironmentMonitor.Infrastructure.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.15.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.6.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.11" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.40.0" />

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
@@ -20,7 +20,7 @@
         "@reduxjs/toolkit": "^2.5.0",
         "@types/node": "^22.15.17",
         "@types/qs": "^6.9.18",
-        "axios": "^1.7.7",
+        "axios": "^1.11.0",
         "chart.js": "^4.4.6",
         "chartjs-adapter-moment": "^1.0.1",
         "chartjs-plugin-zoom": "^2.2.0",
@@ -2954,13 +2954,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -4205,14 +4205,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
@@ -22,7 +22,7 @@
     "@reduxjs/toolkit": "^2.5.0",
     "@types/node": "^22.15.17",
     "@types/qs": "^6.9.18",
-    "axios": "^1.7.7",
+    "axios": "^1.11.0",
     "chart.js": "^4.4.6",
     "chartjs-adapter-moment": "^1.0.1",
     "chartjs-plugin-zoom": "^2.2.0",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/MultiSensorGraph.tsx
@@ -85,6 +85,8 @@ interface GraphDataset {
   sensorId: number;
 }
 
+const dynamicColorLimit = 7;
+
 export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
   sensors,
   model,
@@ -417,11 +419,12 @@ export const MultiSensorGraph: React.FC<MultiSensorGraphProps> = ({
                   text: "Chart.js Time Scale",
                   display: true,
                 },
-                colors: useDynamicColors
-                  ? undefined
-                  : {
-                      forceOverride: true,
-                    },
+                colors:
+                  useDynamicColors || memoSets.length > dynamicColorLimit
+                    ? undefined
+                    : {
+                        forceOverride: true,
+                      },
                 legend: {
                   onClick: (_event, legendItem, legend) => {
                     if (legendItem.datasetIndex === undefined) {


### PR DESCRIPTION
- Updated Magick.NET. Fixes vulnerabilities. 
- Updated Azure.Identity. The previously used version was deprecated.
- In ``MultiSensorGraph``, dynamic colors are always taken into use in case there are more than 7 datasets. The used color palette only has seven colors.
- Updated Axios. Fixes vulnerabilities. 