### PR TITLE
Added functionality for showing device-identifier (IoT hub) in the UI

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/DeviceInfoDto.cs
@@ -14,6 +14,7 @@ namespace EnvironmentMonitor.Application.DTOs
         public DateTime? LastMessage { get; set; }
         public List<DeviceAttachmentDto> Attachments { get; set; } = [];
         public Guid? DefaultImageGuid { get; set; }
+        public string DeviceIdentifier { get; set; }
 
         public bool ShowWarning { get; set; }
         public void Mapping(Profile profile)
@@ -21,6 +22,7 @@ namespace EnvironmentMonitor.Application.DTOs
             profile.CreateMap<DeviceInfo, DeviceInfoDto>()
                 .ForMember(x => x.ShowWarning, opt => opt.MapFrom<ShowDeviceWarningResolver>())
                 .ForMember(x => x.Attachments, opt => opt.MapFrom(x => x.Device.Attachments ?? new List<DeviceAttachment>()))
+                .ForMember(x => x.DeviceIdentifier, opt => opt.MapFrom(x => x.Device.DeviceIdentifier))
                 .ReverseMap();
         }
     }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package-lock.json
@@ -20,7 +20,7 @@
         "@reduxjs/toolkit": "^2.5.0",
         "@types/node": "^22.15.17",
         "@types/qs": "^6.9.18",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "chart.js": "^4.4.6",
         "chartjs-adapter-moment": "^1.0.1",
         "chartjs-plugin-zoom": "^2.2.0",
@@ -2954,9 +2954,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/package.json
@@ -22,7 +22,7 @@
     "@reduxjs/toolkit": "^2.5.0",
     "@types/node": "^22.15.17",
     "@types/qs": "^6.9.18",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "chart.js": "^4.4.6",
     "chartjs-adapter-moment": "^1.0.1",
     "chartjs-plugin-zoom": "^2.2.0",

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -277,7 +277,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       headerName: "Identifier",
       hideable: true,
       flex: 1,
-      minWidth: 150,
+      minWidth: 200,
       valueGetter: (_value, row) => (row as DeviceInfo).deviceIdentifier,
     });
   }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -274,10 +274,10 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
   if (showDeviceIdentifier) {
     columns.splice(1, 0, {
       field: "deviceIdentifier",
-      headerName: "Device Identifier",
+      headerName: "Identifier",
       hideable: true,
       flex: 1,
-      minWidth: 200,
+      minWidth: 150,
       valueGetter: (_value, row) => (row as DeviceInfo).deviceIdentifier,
     });
   }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceTable.tsx
@@ -24,6 +24,7 @@ export interface DeviceTableProps {
   hideId?: boolean;
   renderLink?: boolean;
   renderLinkToDeviceMessages?: boolean;
+  showDeviceIdentifier?: boolean;
 }
 
 export const DeviceTable: React.FC<DeviceTableProps> = ({
@@ -36,6 +37,7 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
   renderLink,
   onClickVisible,
   renderLinkToDeviceMessages,
+  showDeviceIdentifier,
 }) => {
   const formatDate = (input: Date | undefined | null) => {
     if (input) {
@@ -268,6 +270,17 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       },
     },
   ];
+
+  if (showDeviceIdentifier) {
+    columns.splice(1, 0, {
+      field: "deviceIdentifier",
+      headerName: "Device Identifier",
+      hideable: true,
+      flex: 1,
+      minWidth: 200,
+      valueGetter: (_value, row) => (row as DeviceInfo).deviceIdentifier,
+    });
+  }
 
   const [selectedDeviceIdentifier, setSelectedDeviceIdentifier] = useState<
     string | undefined

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -434,6 +434,7 @@ export const DeviceView: React.FC = () => {
         <Collapsible title="Info" isOpen={true}>
           <DeviceTable
             hideName
+            showDeviceIdentifier
             onClickVisible={(device) => {
               dispatch(
                 setConfirmDialog({

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceInfo.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/deviceInfo.ts
@@ -9,4 +9,5 @@ export interface DeviceInfo {
   showWarning?: boolean;
   attachments: DeviceAttachment[];
   defaultImageGuid: string;
+  deviceIdentifier: string;
 }


### PR DESCRIPTION
- DeviceIdentifier is now mapped in the ``DeviceInfoDto`` . In ``DeviceInfoDto`` instead of ``DeviceDto`` to reduce the amount of information available in ``DeviceDto``.
- In the UI, Deviceidentífier is shown in the ``DeviceView``. In ``DeviceTable``, there is a prop for controlling whether to show it or not.
- Also, updated axios as a vulnerability was reported.