### PR TITLE
Removed unused console log, support for using DeviceIdentifiers as filters when fetching measurements

### DIFF
--- a/src/EnvironmentMonitor.Application/Services/MeasurementService.cs
+++ b/src/EnvironmentMonitor.Application/Services/MeasurementService.cs
@@ -157,9 +157,14 @@ namespace EnvironmentMonitor.Application.Services
                 throw new UnauthorizedAccessException();
             }
 
-            if (!_userService.IsAdmin && model.SensorIdentifiers.Count == 0)
+            if (model.DeviceIdentifiers.Any(d => !_userService.HasAccessToDevice(d, AccessLevels.Read)))
             {
-                throw new InvalidOperationException("SensorIds must be defined");
+                throw new UnauthorizedAccessException();
+            }
+
+            if (!_userService.IsAdmin && model.SensorIdentifiers.Count == 0 && model.DeviceIdentifiers.Count == 0)
+            {
+                throw new InvalidOperationException("SensorIdentifiers or DeviceIdentifiers must be defined");
             }
 
             var measurementRows = await _measurementRepository.GetMeasurements(model);

--- a/src/EnvironmentMonitor.Domain/Models/GetMeasurementsModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/GetMeasurementsModel.cs
@@ -10,6 +10,7 @@ namespace EnvironmentMonitor.Domain.Models
     public class GetMeasurementsModel
     {
         public List<Guid> SensorIdentifiers { get; set; } = [];
+        public List<Guid> DeviceIdentifiers { get; set; } = [];
         /// <summary>
         /// If no sensor ids provided, and this filter is provided, it will filter by sensors and for each sensor, on measurement types in the Dictionary.
         /// </summary>

--- a/src/EnvironmentMonitor.Infrastructure/Data/MeasurementRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/MeasurementRepository.cs
@@ -51,6 +51,11 @@ namespace EnvironmentMonitor.Infrastructure.Data
                 query = query.Where(predicate);
             }
 
+            if (model.DeviceIdentifiers.Any())
+            {
+                query = query.Where(x => model.DeviceIdentifiers.Contains(x.Sensor.Device.Identifier));
+            }
+
             if (model.DeviceMessageIdentifiers?.Any() == true)
             {
                 query = query.Where(x => x.DeviceMessage != null && !x.DeviceMessage.IsDuplicate && !string.IsNullOrEmpty(x.DeviceMessage.Identifier) && model.DeviceMessageIdentifiers.Contains(x.DeviceMessage.Identifier));

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceMessageTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/DeviceMessageTable.tsx
@@ -38,9 +38,6 @@ export const DeviceMessagesTable: React.FC<Props> = ({
   const drawDesktop = useMediaQuery(theme.breakpoints.up("lg"));
 
   useEffect(() => {
-    console.log(deviceInfos);
-  }, [deviceInfos]);
-  useEffect(() => {
     if (!model) {
       return;
     }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceMessagesView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceMessagesView.tsx
@@ -105,6 +105,7 @@ export const DeviceMessagesView: React.FC = () => {
       .getMeasurements({
         deviceMessageIdentifiers: [message.identifier],
         sensorIdentifiers: [],
+        deviceIdentifiers: [message.deviceIdentifier],
       })
       .then((res) => {
         setMeasurementsModel(res);

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/getMeasurementsModel.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/getMeasurementsModel.ts
@@ -1,6 +1,7 @@
 export interface GetMeasurementsModel {
   sensorIdentifiers: string[];
   deviceMessageIdentifiers?: string[];
+  deviceIdentifiers?: string[];
   latestOnly?: boolean;
   from?: moment.Moment;
   to?: moment.Moment;


### PR DESCRIPTION
- Added support for using DeviceIdentifiers as filters when fetching measurements. Took this into use when fetching measurements related to device messages
- Removed unused console.log