### PR TITLE
Support for editing devices

### DIFF
--- a/src/EnvironmentMonitor.Application/DTOs/UpdateDeviceDto.cs
+++ b/src/EnvironmentMonitor.Application/DTOs/UpdateDeviceDto.cs
@@ -10,5 +10,6 @@ namespace EnvironmentMonitor.Application.DTOs
     {
         public required DeviceDto Device { get; set; }
         public int? CommunicationChannelId { get; set; }
+        public string? DeviceIdentifier { get; set; }
     }
 }

--- a/src/EnvironmentMonitor.Application/Services/DeviceService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceService.cs
@@ -387,10 +387,18 @@ namespace EnvironmentMonitor.Application.Services
             {
                 throw new UnauthorizedAccessException();
             }
+
             var device = (await _deviceRepository.GetDevices(new GetDevicesModel() { Identifiers = [model.Device.Identifier] })).FirstOrDefault() ?? throw new EntityNotFoundException($"Device with identifier: '{model.Device.Identifier}' not found.");
             var updateModel = _mapper.Map<Device>(model.Device);
             updateModel.Id = device.Id;
             updateModel.CommunicationChannelId = model.CommunicationChannelId;
+
+            if (!string.IsNullOrEmpty(model.DeviceIdentifier))
+            {
+                _logger.LogInformation($"Updating device identifier for device '{device.Name}' to '{model.DeviceIdentifier}'");
+                updateModel.DeviceIdentifier = model.DeviceIdentifier;
+            }            
+
             var info = await _deviceRepository.AddOrUpdate(updateModel, true);
             return _mapper.Map<DeviceInfoDto>(info);
         }

--- a/src/EnvironmentMonitor.Domain/Entities/Device.cs
+++ b/src/EnvironmentMonitor.Domain/Entities/Device.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace EnvironmentMonitor.Domain.Entities
 {
-    public class Device
+    public class Device: TrackedEntity
     {
         public int Id { get; set; }
         public Guid Identifier { get; set; }

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -349,10 +349,12 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 await _context.SaveChangesAsync();
             }
+
             var toReturn = (await GetDeviceInfo(new GetDevicesModel()
             {
                 Ids = [deviceToUpdate.Id],
                 GetAttachments = true,
+                GetLocation = true,
                 OnlyVisible = false
             }))
             .FirstOrDefault();

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -326,7 +326,7 @@ namespace EnvironmentMonitor.Infrastructure.Data
             }
             else
             {
-                deviceToUpdate = new Device() { Name = device.Name, DeviceIdentifier = device.DeviceIdentifier };
+                deviceToUpdate = new Device() { Name = device.Name, DeviceIdentifier = device.DeviceIdentifier, Created = _dateService.CurrentTime() };
             }
 
             deviceToUpdate.Name = string.IsNullOrEmpty(device.Name) ? deviceToUpdate.Name : device.Name;

--- a/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/DeviceRepository.cs
@@ -334,6 +334,12 @@ namespace EnvironmentMonitor.Infrastructure.Data
             deviceToUpdate.Visible = device.Visible;
             deviceToUpdate.CommunicationChannelId = device.CommunicationChannelId;
 
+            if (!string.IsNullOrEmpty(device.DeviceIdentifier) && !device.DeviceIdentifier.Equals(deviceToUpdate.DeviceIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation($"Updating device identifier for device id: {deviceToUpdate.Id} from '{deviceToUpdate.DeviceIdentifier}' to '{device.DeviceIdentifier}'");
+                deviceToUpdate.DeviceIdentifier = device.DeviceIdentifier;
+            }
+
             if (deviceInDb == null)
             {
                 _logger.LogInformation($"Adding device named: '{deviceToUpdate.Name}'");

--- a/src/EnvironmentMonitor.Infrastructure/Data/MeasurementDbContext.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/MeasurementDbContext.cs
@@ -1,4 +1,5 @@
 using EnvironmentMonitor.Domain.Entities;
+using EnvironmentMonitor.Domain.Interfaces;
 using EnvironmentMonitor.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -12,9 +13,12 @@ namespace EnvironmentMonitor.Infrastructure.Data
 {
     public class MeasurementDbContext : DbContext
     {
-        public MeasurementDbContext(DbContextOptions<MeasurementDbContext> options)
+        private readonly IDateService _dateService;
+
+        public MeasurementDbContext(DbContextOptions<MeasurementDbContext> options, IDateService dateService)
             : base(options)
         {
+            _dateService = dateService;
         }
 
         protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
@@ -45,7 +49,34 @@ namespace EnvironmentMonitor.Infrastructure.Data
         public DbSet<EmailTemplate> EmailTemplates { get; set; }
         public DbSet<DeviceContact> DeviceContacts { get; set; }
         public DbSet<CommunicationChannel> CommunicationChannels { get; set; }
-        
+
+        public override int SaveChanges()
+        {
+            StampEntities();
+            return base.SaveChanges();
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            StampEntities();
+            return base.SaveChangesAsync(cancellationToken);
+        }
+
+        private void StampEntities()
+        {
+            var now = _dateService.CurrentTime();
+            var utcNow = _dateService.LocalToUtc(now);
+
+            foreach (var entry in ChangeTracker.Entries<TrackedEntity>())
+            {
+                if (entry.State == EntityState.Modified)
+                {
+                    entry.Entity.Updated ??= now;
+                    entry.Entity.UpdatedUtc ??= utcNow;
+                }
+            }
+        }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.ApplyConfigurationsFromAssembly(typeof(MeasurementDbContext).Assembly, type =>

--- a/src/EnvironmentMonitor.Infrastructure/Data/MeasurementDbContext.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/MeasurementDbContext.cs
@@ -71,8 +71,8 @@ namespace EnvironmentMonitor.Infrastructure.Data
             {
                 if (entry.State == EntityState.Modified)
                 {
-                    entry.Entity.Updated ??= now;
-                    entry.Entity.UpdatedUtc ??= utcNow;
+                    entry.Entity.Updated = now;
+                    entry.Entity.UpdatedUtc = utcNow;
                 }
             }
         }

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20260524194854_AddTrackedEntityFieldsToDevice.Designer.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20260524194854_AddTrackedEntityFieldsToDevice.Designer.cs
@@ -4,6 +4,7 @@ using EnvironmentMonitor.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnvironmentMonitor.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(MeasurementDbContext))]
-    partial class MeasurementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524194854_AddTrackedEntityFieldsToDevice")]
+    partial class AddTrackedEntityFieldsToDevice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20260524194854_AddTrackedEntityFieldsToDevice.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/Migrations/20260524194854_AddTrackedEntityFieldsToDevice.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnvironmentMonitor.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrackedEntityFieldsToDevice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "Devices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedUtc",
+                table: "Devices",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Updated",
+                table: "Devices",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedUtc",
+                table: "Devices",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Devices");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedUtc",
+                table: "Devices");
+
+            migrationBuilder.DropColumn(
+                name: "Updated",
+                table: "Devices");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedUtc",
+                table: "Devices");
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Migrations/Program.cs
+++ b/src/EnvironmentMonitor.Migrations/Program.cs
@@ -86,7 +86,8 @@ class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<MeasurementDbCont
         // Configure the DbContext to use SQL Server
         builder.UseSqlServer(connectionString);
 
-        return new MeasurementDbContext(builder.Options);
+        var dateService = new DateService(new Microsoft.Extensions.Logging.Abstractions.NullLogger<DateService>());
+        return new MeasurementDbContext(builder.Options, dateService);
     }
 }
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceTable.tsx
@@ -24,9 +24,11 @@ import {
   CommunicationChannels,
   getCommunicationChannelDisplayName,
 } from "../../enums/communicationChannels";
+import type { LocationModel } from "../../models/location";
 
 export interface DeviceTableProps {
   devices: DeviceInfo[];
+  locations?: LocationModel[];
   onReboot?: (device: DeviceInfo) => void;
   onClickVisible?: (device: DeviceInfo) => void;
   onCommunicationChannelChange?: (
@@ -45,6 +47,7 @@ export interface DeviceTableProps {
 
 export const DeviceTable: React.FC<DeviceTableProps> = ({
   devices,
+  locations,
   title,
   disableSort,
   hideName,
@@ -362,6 +365,29 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
       flex: 1,
       minWidth: 200,
       valueGetter: (_value, row) => (row as DeviceInfo).deviceIdentifier,
+    });
+  }
+
+  if (locations && locations.length > 0) {
+    columns.splice(2, 0, {
+      field: "location",
+      headerName: "Location",
+      hideable: true,
+      flex: 1,
+      minWidth: 200,
+      renderCell: (params) => {
+        const row = params.row as DeviceInfo;
+
+        const location = locations.find(
+          (l) => l.identifier === row.device.locationIdentifier,
+        );
+
+        return (
+          <Link to={`${routes.locations}/${location?.identifier}`}>
+            {location?.name ?? "-"}
+          </Link>
+        );
+      },
     });
   }
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/EditDeviceDialog.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/EditDeviceDialog.tsx
@@ -1,0 +1,160 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
+import { Close } from "@mui/icons-material";
+import { useEffect, useState } from "react";
+import type { DeviceInfo } from "../../models/deviceInfo";
+import type { UpdateDeviceDto } from "../../models/updateDeviceDto";
+import {
+  CommunicationChannels,
+  getCommunicationChannelDisplayName,
+} from "../../enums/communicationChannels";
+
+export interface EditDeviceDialogProps {
+  open: boolean;
+  device?: DeviceInfo;
+  onClose: () => void;
+  onSave: (model: UpdateDeviceDto) => void;
+}
+
+export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
+  open,
+  device,
+  onClose,
+  onSave,
+}) => {
+  const [name, setName] = useState("");
+  const [deviceIdentifier, setDeviceIdentifier] = useState("");
+  const [visible, setVisible] = useState(false);
+  const [communicationChannelId, setCommunicationChannelId] = useState(0);
+
+  useEffect(() => {
+    if (!open || !device) {
+      return;
+    }
+
+    setName(device.device.name);
+    setDeviceIdentifier(device.deviceIdentifier);
+    setVisible(device.device.visible);
+    setCommunicationChannelId(device.communicationChannelId ?? 0);
+  }, [device, open]);
+
+  const handleSave = () => {
+    if (!device || !name.trim() || !deviceIdentifier.trim()) {
+      return;
+    }
+
+    onSave({
+      device: {
+        ...device.device,
+        name: name.trim(),
+        visible,
+      },
+      communicationChannelId,
+      deviceIdentifier: deviceIdentifier.trim(),
+    });
+    onClose();
+  };
+
+  const isSaveDisabled =
+    !device ||
+    !name.trim() ||
+    !deviceIdentifier.trim() ||
+    (name.trim() === device.device.name &&
+      deviceIdentifier.trim() === device.deviceIdentifier &&
+      visible === device.device.visible &&
+      communicationChannelId === (device.communicationChannelId ?? 0));
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <Box>Edit Device</Box>
+        <IconButton onClick={onClose} size="small" aria-label="close">
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Box display="flex" flexDirection="column" gap={2} pt={1}>
+          <TextField
+            autoFocus
+            label="Name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            fullWidth
+            required
+          />
+          <TextField
+            label="Device identifier"
+            value={deviceIdentifier}
+            onChange={(event) => setDeviceIdentifier(event.target.value)}
+            fullWidth
+            required
+          />
+          <FormControl fullWidth>
+            <InputLabel id="device-communication-channel-label">
+              Communication channel
+            </InputLabel>
+            <Select
+              labelId="device-communication-channel-label"
+              label="Communication channel"
+              value={communicationChannelId}
+              onChange={(event) =>
+                setCommunicationChannelId(event.target.value as number)
+              }
+            >
+              {Object.values(CommunicationChannels)
+                .filter((value) => typeof value === "number")
+                .map((value) => (
+                  <MenuItem key={value} value={value}>
+                    {getCommunicationChannelDisplayName(
+                      value as CommunicationChannels,
+                    )}
+                  </MenuItem>
+                ))}
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={visible}
+                onChange={(event) => setVisible(event.target.checked)}
+              />
+            }
+            label="Visible"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={isSaveDisabled}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/EditDeviceDialog.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/EditDeviceDialog.tsx
@@ -36,47 +36,56 @@ export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
   onClose,
   onSave,
 }) => {
-  const [name, setName] = useState("");
-  const [deviceIdentifier, setDeviceIdentifier] = useState("");
-  const [visible, setVisible] = useState(false);
-  const [communicationChannelId, setCommunicationChannelId] = useState(0);
+  const [model, setModel] = useState<UpdateDeviceDto | undefined>(undefined);
+
+  const createModel = (device: DeviceInfo): UpdateDeviceDto => ({
+    device: { ...device.device },
+    communicationChannelId: device.communicationChannelId ?? 0,
+    deviceIdentifier: device.deviceIdentifier,
+  });
 
   useEffect(() => {
     if (!open || !device) {
       return;
     }
 
-    setName(device.device.name);
-    setDeviceIdentifier(device.deviceIdentifier);
-    setVisible(device.device.visible);
-    setCommunicationChannelId(device.communicationChannelId ?? 0);
+    setModel(createModel(device));
   }, [device, open]);
 
   const handleSave = () => {
-    if (!device || !name.trim() || !deviceIdentifier.trim()) {
+    if (!model || !model.device.name.trim() || !model.deviceIdentifier?.trim()) {
       return;
     }
 
     onSave({
-      device: {
-        ...device.device,
-        name: name.trim(),
-        visible,
-      },
-      communicationChannelId,
-      deviceIdentifier: deviceIdentifier.trim(),
+      ...model,
+      device: { ...model.device, name: model.device.name.trim() },
+      deviceIdentifier: model.deviceIdentifier.trim(),
     });
     onClose();
   };
 
+  const hasChanges =
+    !!device &&
+    !!model &&
+    (model.device.name.trim() !== device.device.name ||
+      model.deviceIdentifier?.trim() !== device.deviceIdentifier ||
+      model.device.visible !== device.device.visible ||
+      model.communicationChannelId !== (device.communicationChannelId ?? 0));
+
   const isSaveDisabled =
-    !device ||
-    !name.trim() ||
-    !deviceIdentifier.trim() ||
-    (name.trim() === device.device.name &&
-      deviceIdentifier.trim() === device.deviceIdentifier &&
-      visible === device.device.visible &&
-      communicationChannelId === (device.communicationChannelId ?? 0));
+    !model ||
+    !model.device.name.trim() ||
+    !model.deviceIdentifier?.trim() ||
+    !hasChanges;
+
+  const handleRevert = () => {
+    if (!device) {
+      return;
+    }
+
+    setModel(createModel(device));
+  };
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -97,15 +106,33 @@ export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
           <TextField
             autoFocus
             label="Name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
+            value={model?.device.name ?? ""}
+            onChange={(event) =>
+              setModel((current) =>
+                current
+                  ? {
+                      ...current,
+                      device: { ...current.device, name: event.target.value },
+                    }
+                  : current,
+              )
+            }
             fullWidth
             required
           />
           <TextField
             label="Device identifier"
-            value={deviceIdentifier}
-            onChange={(event) => setDeviceIdentifier(event.target.value)}
+            value={model?.deviceIdentifier ?? ""}
+            onChange={(event) =>
+              setModel((current) =>
+                current
+                  ? {
+                      ...current,
+                      deviceIdentifier: event.target.value,
+                    }
+                  : current,
+              )
+            }
             fullWidth
             required
           />
@@ -116,9 +143,16 @@ export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
             <Select
               labelId="device-communication-channel-label"
               label="Communication channel"
-              value={communicationChannelId}
+              value={model?.communicationChannelId ?? 0}
               onChange={(event) =>
-                setCommunicationChannelId(event.target.value as number)
+                setModel((current) =>
+                  current
+                    ? {
+                        ...current,
+                        communicationChannelId: event.target.value as number,
+                      }
+                    : current,
+                )
               }
             >
               {Object.values(CommunicationChannels)
@@ -135,8 +169,20 @@ export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
           <FormControlLabel
             control={
               <Checkbox
-                checked={visible}
-                onChange={(event) => setVisible(event.target.checked)}
+                checked={model?.device.visible ?? false}
+                onChange={(event) =>
+                  setModel((current) =>
+                    current
+                      ? {
+                          ...current,
+                          device: {
+                            ...current.device,
+                            visible: event.target.checked,
+                          },
+                        }
+                      : current,
+                  )
+                }
               />
             }
             label="Visible"
@@ -146,6 +192,9 @@ export const EditDeviceDialog: React.FC<EditDeviceDialogProps> = ({
       <DialogActions>
         <Button onClick={onClose} color="inherit">
           Cancel
+        </Button>
+        <Button onClick={handleRevert} color="inherit" disabled={!hasChanges}>
+          Revert
         </Button>
         <Button
           variant="contained"

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -899,7 +899,7 @@ export const DeviceView: React.FC = () => {
       isLoading={isLoading}
       titleComponent={
         selectedDevice ? (
-          <>
+          <Box display="flex" alignItems="center" gap={1}>
             <Tooltip title="Refresh device">
               <IconButton
                 onClick={() => loadDeviceData(selectedDevice.device.identifier)}
@@ -917,7 +917,7 @@ export const DeviceView: React.FC = () => {
                 <Edit />
               </IconButton>
             </Tooltip>
-          </>
+          </Box>
         ) : undefined
       }
     >

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -899,13 +899,25 @@ export const DeviceView: React.FC = () => {
       isLoading={isLoading}
       titleComponent={
         selectedDevice ? (
-          <Tooltip title="Refresh device">
-            <IconButton
-              onClick={() => loadDeviceData(selectedDevice.device.identifier)}
-            >
-              <Refresh />
-            </IconButton>
-          </Tooltip>
+          <>
+            <Tooltip title="Refresh device">
+              <IconButton
+                onClick={() => loadDeviceData(selectedDevice.device.identifier)}
+              >
+                <Refresh />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Edit device">
+              <IconButton
+                onClick={() => setEditDeviceDialogOpen(true)}
+                sx={{ ml: 1, cursor: "pointer" }}
+                size="small"
+                title="Edit device"
+              >
+                <Edit />
+              </IconButton>
+            </Tooltip>
+          </>
         ) : undefined
       }
     >
@@ -915,22 +927,7 @@ export const DeviceView: React.FC = () => {
         flexDirection={"column"}
         height={"100%"}
       >
-        <Collapsible
-          title="Info"
-          isOpen={true}
-          customComponent={
-            selectedDevice ? (
-              <IconButton
-                onClick={() => setEditDeviceDialogOpen(true)}
-                sx={{ ml: 1, cursor: "pointer" }}
-                size="small"
-                title="Edit device"
-              >
-                <Edit />
-              </IconButton>
-            ) : undefined
-          }
-        >
+        <Collapsible title="Info" isOpen={true} customComponent={undefined}>
           <DeviceTable
             hideName
             showDeviceIdentifier

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -7,7 +7,7 @@ import { SensorTable } from "../components/Sensors/SensorTable";
 import { DeviceTable } from "../components/Devices/DeviceTable";
 import { DeviceControlComponent } from "../components/Devices/DeviceControlComponent";
 import { DeviceAttributesTable } from "../components/Devices/DeviceAttributesTable";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
   addNotification,
   setConfirmDialog,
@@ -24,7 +24,7 @@ import moment from "moment";
 import { type MeasurementsViewModel } from "../models/measurementsBySensor";
 import { type DeviceStatusModel } from "../models/deviceStatus";
 import { MeasurementTypes } from "../enums/measurementTypes";
-import { setDevices } from "../reducers/measurementReducer";
+import { getLocations, setDevices } from "../reducers/measurementReducer";
 import { getEntityTitle } from "../utilities/entityUtils";
 import { TimeRangeSelectorComponent } from "../components/Measurements/TimeRangeSelectorComponent";
 import { DeviceAttachments } from "../components/Devices/DeviceAttachments";
@@ -48,6 +48,7 @@ export const DeviceView: React.FC = () => {
     undefined,
   );
   const [deviceEvents, setDeviceEvents] = useState<DeviceEvent[]>([]);
+  const locations = useSelector(getLocations);
   const [queuedCommands, setQueuedCommands] = useState<
     DeviceQueuedCommandDto[]
   >([]);
@@ -937,6 +938,7 @@ export const DeviceView: React.FC = () => {
             devices={selectedDevice ? [selectedDevice] : []}
             disableSort
             renderLinkToDeviceMessages
+            locations={locations}
           />
         </Collapsible>
 

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -30,13 +30,15 @@ import { TimeRangeSelectorComponent } from "../components/Measurements/TimeRange
 import { DeviceAttachments } from "../components/Devices/DeviceAttachments";
 import { DeviceContacts } from "../components/Devices/DeviceContacts";
 import { DeviceContactDialog } from "../components/Devices/DeviceContactDialog";
-import { Refresh, Add, VpnKey } from "@mui/icons-material";
+import { Refresh, Add, VpnKey, Edit } from "@mui/icons-material";
 import { type DeviceContact } from "../models/deviceContact";
 import { ApiKeyDialog } from "../components/ApiKeys/ApiKeyDialog";
 import type { AddOrUpdateSensor } from "../models/addOrUpdateSensor";
 import type { SensorInfo } from "../models/sensor";
 import { SensorDialog } from "../components/Sensors/SensorDialog";
 import type { AddVirtualSensorRowDto } from "../models/updateVirtualSensorRows";
+import { EditDeviceDialog } from "../components/Devices/EditDeviceDialog";
+import type { UpdateDeviceDto } from "../models/updateDeviceDto";
 
 const timeRangeDefaultDays = 7;
 const measurementTimeRangeDefaultHours = 48;
@@ -82,6 +84,7 @@ export const DeviceView: React.FC = () => {
   } | null>(null);
   const [sensorDialogOpen, setSensorDialogOpen] = useState(false);
   const [selectedSensor, setSelectedSensor] = useState<SensorInfo | null>(null);
+  const [editDeviceDialogOpen, setEditDeviceDialogOpen] = useState(false);
 
   const dispatch = useDispatch();
 
@@ -383,56 +386,15 @@ export const DeviceView: React.FC = () => {
       });
   };
 
-  const updateVisible = (device: DeviceInfo) => {
+  const updateDevice = (model: UpdateDeviceDto) => {
     setIsLoading(true);
     deviceHook
-      .updateDevice({
-        device: { ...device.device, visible: !device.device.visible },
-      })
+      .updateDevice(model)
       .then((res) => {
         setSelectedDevice(res);
         dispatch(
           addNotification({
-            title: `Visibility status updated for ${res.device.name}`,
-            body: "_",
-            severity: "success",
-          }),
-        );
-        // Update devices
-        measurementApiHook
-          .getDevices()
-          .then((res) => {
-            if (res) {
-              dispatch(setDevices(res));
-            }
-          })
-          .catch((ex) => {
-            console.error(ex);
-          });
-      })
-      .catch((er) => {
-        console.error(er);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  };
-
-  const updateCommunicationChannel = (
-    device: DeviceInfo,
-    channelId: number,
-  ) => {
-    setIsLoading(true);
-    deviceHook
-      .updateDevice({
-        device: device.device,
-        communicationChannelId: channelId,
-      })
-      .then((res) => {
-        setSelectedDevice(res);
-        dispatch(
-          addNotification({
-            title: `Communication channel updated for ${res.device.name}`,
+            title: `Device updated for ${res.device.name}`,
             body: "_",
             severity: "success",
           }),
@@ -952,35 +914,26 @@ export const DeviceView: React.FC = () => {
         flexDirection={"column"}
         height={"100%"}
       >
-        <Collapsible title="Info" isOpen={true}>
+        <Collapsible
+          title="Info"
+          isOpen={true}
+          customComponent={
+            selectedDevice ? (
+              <IconButton
+                onClick={() => setEditDeviceDialogOpen(true)}
+                sx={{ ml: 1, cursor: "pointer" }}
+                size="small"
+                title="Edit device"
+              >
+                <Edit />
+              </IconButton>
+            ) : undefined
+          }
+        >
           <DeviceTable
             hideName
             showDeviceIdentifier
             hideId
-            onClickVisible={(device) => {
-              dispatch(
-                setConfirmDialog({
-                  onConfirm: () => {
-                    updateVisible(device);
-                  },
-                  title: "Update visible status",
-                  body: `Visible status will be ${!device.device.visible} for ${
-                    device.device.name
-                  }`,
-                }),
-              );
-            }}
-            onCommunicationChannelChange={(device, channelId) => {
-              dispatch(
-                setConfirmDialog({
-                  onConfirm: () => {
-                    updateCommunicationChannel(device, channelId);
-                  },
-                  title: "Update communication channel",
-                  body: `Communication channel will be updated for ${device.device.name}`,
-                }),
-              );
-            }}
             devices={selectedDevice ? [selectedDevice] : []}
             disableSort
             renderLinkToDeviceMessages
@@ -1318,6 +1271,12 @@ export const DeviceView: React.FC = () => {
         onGenerate={handleGenerateApiKey}
         generatedKey={generatedApiKey}
         isLoading={isLoading}
+      />
+      <EditDeviceDialog
+        open={editDeviceDialogOpen}
+        device={selectedDevice}
+        onClose={() => setEditDeviceDialogOpen(false)}
+        onSave={updateDevice}
       />
       <SensorDialog
         open={sensorDialogOpen}

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/updateDeviceDto.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/models/updateDeviceDto.ts
@@ -3,4 +3,5 @@ import type { Device } from "./device";
 export interface UpdateDeviceDto {
   device: Device;
   communicationChannelId?: number;
+  deviceIdentifier?: string;
 }

--- a/tests/EnvironmentMonitor.Tests/BaseIntegrationTest.cs
+++ b/tests/EnvironmentMonitor.Tests/BaseIntegrationTest.cs
@@ -314,7 +314,8 @@ namespace EnvironmentMonitor.Tests
                             SensorId = 2
                         }
                     ],
-                    Location = location
+                    Location = location,
+                    Created = DateTime.Now,
                 };
 
                 var deviceWithBaseLocation = new Device()
@@ -326,7 +327,8 @@ namespace EnvironmentMonitor.Tests
                         Name = "Test-01",
                         SensorId = 1
                     }],
-                    Location = measurementDbContext.Locations.First(x => x.Id == 0)
+                    Location = measurementDbContext.Locations.First(x => x.Id == 0),
+                    Created = DateTime.Now,
                 };
 
 
@@ -338,7 +340,8 @@ namespace EnvironmentMonitor.Tests
                         Name = "Test-01",
                         SensorId = 1
                     }],
-                    Location = locationWithNoAccess
+                    Location = locationWithNoAccess,
+                    Created = DateTime.Now,
                 };
                 measurementDbContext.Devices.Add(deviceWithBaseLocation);
                 measurementDbContext.Devices.Add(deviceInLocation);


### PR DESCRIPTION
Added support for editing devices in the UI.

- Changed backend so that DeviceIdentifier can be set. It is now included in ``UpdateDeviceDto``
- In the UI, added ``EditDeviceDialog`` which can be used to set the defined properties of device (name, deviceidentifier, communication channel, visible)
- Derived device from ``TrackedEntity``. 
- Added support for automatically setting updated property for entities derived from ``TrackedEntity``