### PR TITLE
Support for sending commands to multiple devices

### DIFF
--- a/src/EnvironmentMonitor.Application/Interfaces/IDeviceCommandService.cs
+++ b/src/EnvironmentMonitor.Application/Interfaces/IDeviceCommandService.cs
@@ -1,5 +1,6 @@
 using EnvironmentMonitor.Application.DTOs;
 using EnvironmentMonitor.Domain.Enums;
+using EnvironmentMonitor.Domain.Models;
 using EnvironmentMonitor.Domain.Models.GetModels;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,9 @@ namespace EnvironmentMonitor.Application.Interfaces
         // Device command methods moved from IDeviceService
         Task Reboot(Guid identifier);
         Task<List<DeviceAttributeDto>> SetMotionControlStatus(Guid identifier, MotionControlStatus status, DateTime? triggeringTime = null);
+        Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlStatus(SetMotionControlStatusMessage model);
         Task<List<DeviceAttributeDto>> SetMotionControlDelay(Guid identifier, long delayMs, DateTime? triggeringTime = null);
+        Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlDelay(SetMotionControlDelayMessage model);
         Task SendAttributesToDevice(Guid identifier, string? message = null);       
         Task<Dictionary<int, string>> GetDeviceAttributes(string deviceIdentifier);
     }

--- a/src/EnvironmentMonitor.Application/Services/DeviceCommandService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceCommandService.cs
@@ -553,8 +553,8 @@ namespace EnvironmentMonitor.Application.Services
 
             if (devices.Any(d => d.IsVirtual))
             {
-                var virtualDeviceIds = devices.Where(d => d.IsVirtual).Select(d => d.Id);
-                throw new InvalidOperationException($"Cannot send messages to virtual devices: {string.Join(", ", virtualDeviceIds)}");
+                var virtualDeviceIds = devices.Where(d => d.IsVirtual).Select(d => d.Identifier);
+                throw new ArgumentException($"Cannot send messages to virtual devices: {string.Join(", ", virtualDeviceIds)}");
             }
 
             var identifiers = devices.Select(x => x.Identifier).ToList();

--- a/src/EnvironmentMonitor.Application/Services/DeviceCommandService.cs
+++ b/src/EnvironmentMonitor.Application/Services/DeviceCommandService.cs
@@ -212,6 +212,33 @@ namespace EnvironmentMonitor.Application.Services
             return _mapper.Map<List<DeviceAttributeDto>>(updatedAttributes);
         }
 
+        public async Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlStatus(SetMotionControlStatusMessage model)
+        {
+            var results = new Dictionary<Guid, List<DeviceAttributeDto>>();
+
+            var identifiers = await ValidateDeviceMessageModel(model);
+
+            foreach (var identifier in identifiers)
+            {
+                results[identifier] = await SetMotionControlStatus(identifier, (MotionControlStatus)model.Mode, model.ExecuteAt);
+            }
+
+            return results;
+        }
+
+        public async Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlDelay(SetMotionControlDelayMessage model)
+        {
+            var results = new Dictionary<Guid, List<DeviceAttributeDto>>();
+
+            var identifiers = await ValidateDeviceMessageModel(model);
+
+            foreach (var identifier in identifiers)
+            {
+                results[identifier] = await SetMotionControlDelay(identifier, model.DelayMs, model.ExecuteAt);
+            }
+            return results;
+        }
+
         public async Task SendAttributesToDevice(Guid identifier, string? message = null)
         {
             if (!_userService.IsAdmin)
@@ -513,6 +540,26 @@ namespace EnvironmentMonitor.Application.Services
             {
                 throw new ArgumentException($"Invalid triggering time: {target}. Current date: {compareDate}");
             }
+        }
+
+        private async Task<List<Guid>> ValidateDeviceMessageModel (MessageDeviceModel model)
+        {
+            if (!_userService.HasAccessToDevices(model.DeviceIdentifiers, AccessLevels.Write))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var devices = await _deviceRepository.GetDevices(new GetDevicesModel() { Identifiers = model.DeviceIdentifiers });
+
+            if (devices.Any(d => d.IsVirtual))
+            {
+                var virtualDeviceIds = devices.Where(d => d.IsVirtual).Select(d => d.Id);
+                throw new InvalidOperationException($"Cannot send messages to virtual devices: {string.Join(", ", virtualDeviceIds)}");
+            }
+
+            var identifiers = devices.Select(x => x.Identifier).ToList();
+
+            return identifiers;
         }
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
+++ b/src/EnvironmentMonitor.Domain/Models/MessageDeviceModel.cs
@@ -8,7 +8,7 @@ namespace EnvironmentMonitor.Domain.Models
 {
     public class MessageDeviceModel
     {
-        public required Guid DeviceIdentifier { get; set; }
+        public required List<Guid> DeviceIdentifiers { get; set; }
         public DateTime? ExecuteAt { get; set; }
     }
 
@@ -17,12 +17,12 @@ namespace EnvironmentMonitor.Domain.Models
         public int Mode { get; set; }
     }
 
-    public class SetMotionControlDelayMessag : MessageDeviceModel
+    public class SetMotionControlDelayMessage : MessageDeviceModel
     {
         public long DelayMs { get; set; }
     }
 
-    public class SetDefaultImage: MessageDeviceModel
+    public class SetDefaultImage : MessageDeviceModel
     {
         public Guid AttachmentGuid { get; set; }
     }

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceControlComponent.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceControlComponent.tsx
@@ -24,6 +24,7 @@ export interface DeviceControlComponentProps {
   onSetMotionControlDelay: (delay: number, executeAt?: Moment) => void;
   hasMotionSensor: boolean;
   title?: string;
+  disabled?: boolean;
 }
 
 interface CommandDialogState {
@@ -51,6 +52,7 @@ export const DeviceControlComponent: React.FC<DeviceControlComponentProps> = ({
   reboot,
   hasMotionSensor,
   title,
+  disabled,
 }) => {
   const theme = useTheme();
   const drawDesktop = useMediaQuery(theme.breakpoints.up("lg"));
@@ -122,7 +124,12 @@ export const DeviceControlComponent: React.FC<DeviceControlComponentProps> = ({
         flexDirection={drawDesktop ? "row" : "column"}
       >
         {reboot && (
-          <Button variant="contained" color="primary" onClick={reboot}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={reboot}
+            disabled={disabled}
+          >
             Reboot
           </Button>
         )}
@@ -131,6 +138,7 @@ export const DeviceControlComponent: React.FC<DeviceControlComponentProps> = ({
             <Button
               variant="contained"
               color="primary"
+              disabled={disabled}
               onClick={(event) => {
                 setAnchorOutputMode(event.currentTarget);
               }}
@@ -181,6 +189,7 @@ export const DeviceControlComponent: React.FC<DeviceControlComponentProps> = ({
             <Button
               variant="contained"
               color="primary"
+              disabled={disabled}
               onClick={(event) => {
                 setAnchorOutputDelay(event.currentTarget);
               }}
@@ -248,6 +257,7 @@ export const DeviceControlComponent: React.FC<DeviceControlComponentProps> = ({
             onClick={handleDialogConfirm}
             variant="contained"
             color="primary"
+            disabled={disabled}
           >
             Confirm
           </Button>

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceTable.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/components/Devices/DeviceTable.tsx
@@ -11,7 +11,11 @@ import {
 import { routes } from "../../utilities/routes";
 import { Link } from "react-router";
 import { getFormattedDate } from "../../utilities/datetimeUtils";
-import { DataGrid, type GridColDef } from "@mui/x-data-grid";
+import {
+  DataGrid,
+  type GridColDef,
+  type GridRowSelectionModel,
+} from "@mui/x-data-grid";
 import { CheckCircle, Photo, WarningAmber } from "@mui/icons-material";
 import { useState } from "react";
 import { DeviceImageDialog } from "./DeviceImageDialog";
@@ -44,6 +48,9 @@ export interface DeviceTableProps {
   renderLink?: boolean;
   renderLinkToDeviceMessages?: boolean;
   showDeviceIdentifier?: boolean;
+  canSelectDevices?: boolean;
+  selectedDeviceIdentifiers?: string[];
+  onSelectedDeviceIdentifiersChange?: (deviceIdentifiers: string[]) => void;
 }
 
 export const DeviceTable: React.FC<DeviceTableProps> = ({
@@ -59,6 +66,9 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
   onCommunicationChannelChange,
   renderLinkToDeviceMessages,
   showDeviceIdentifier,
+  canSelectDevices,
+  selectedDeviceIdentifiers,
+  onSelectedDeviceIdentifiersChange,
 }) => {
   const formatDate = (input: Date | undefined | null) => {
     if (input) {
@@ -402,6 +412,13 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
     selectedDeviceIdentifier !== undefined
       ? devices.find((d) => d.device.identifier === selectedDeviceIdentifier)
       : undefined;
+  const rowSelectionModel: GridRowSelectionModel | undefined =
+    selectedDeviceIdentifiers !== undefined
+      ? {
+          type: "include",
+          ids: new Set(selectedDeviceIdentifiers),
+        }
+      : undefined;
 
   return (
     <Box marginTop={1} display={"flex"} flexDirection={"column"}>
@@ -439,6 +456,24 @@ export const DeviceTable: React.FC<DeviceTableProps> = ({
           pageSizeOptions={[]}
           disableColumnSorting={disableSort}
           hideFooter
+          checkboxSelection={canSelectDevices}
+          disableRowSelectionOnClick={!canSelectDevices}
+          rowSelection={canSelectDevices}
+          rowSelectionModel={rowSelectionModel}
+          onRowSelectionModelChange={(model) => {
+            if (!onSelectedDeviceIdentifiersChange) {
+              return;
+            }
+            const selectedIds =
+              model.type === "include"
+                ? Array.from(model.ids)
+                : devices
+                    .map((device) => device.device.identifier)
+                    .filter((identifier) => !model.ids.has(identifier));
+            onSelectedDeviceIdentifiersChange(
+              selectedIds.map((identifier) => String(identifier)),
+            );
+          }}
           initialState={{
             columns: {
               columnVisibilityModel:

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/DeviceView.tsx
@@ -432,11 +432,12 @@ export const DeviceView: React.FC = () => {
     deviceHook
       .setMotionControlState(selectedDevice.device.identifier, state, executeAt)
       .then((res) => {
-        if (res && res.length > 0) {
+        const attributes = res[selectedDevice.device.identifier];
+        if (attributes && attributes.length > 0) {
           // Update selectedDevice with new attributes
           setSelectedDevice({
             ...selectedDevice,
-            attributes: res,
+            attributes,
           });
           getDeviceEvents(selectedDevice.device.identifier);
           if (executeAt) {
@@ -484,11 +485,12 @@ export const DeviceView: React.FC = () => {
         executeAt,
       )
       .then((res) => {
-        if (res && res.length > 0) {
+        const attributes = res[selectedDevice.device.identifier];
+        if (attributes && attributes.length > 0) {
           // Update selectedDevice with new attributes
           setSelectedDevice({
             ...selectedDevice,
-            attributes: res,
+            attributes,
           });
           getDeviceEvents(selectedDevice.device.identifier);
           if (executeAt) {

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
@@ -652,6 +652,7 @@ export const LocationView: React.FC = () => {
             <Collapsible title="Location Commands" isOpen={true}>
               <DeviceControlComponent
                 hasMotionSensor={hasMotionControlDevices}
+                disabled={selectedDeviceIdentifiers.length > 0}
                 onSetOutStatic={(mode: boolean, executeAt?: moment.Moment) => {
                   setLocationMotionControlState(
                     mode ? 1 : 0,

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
@@ -604,16 +604,6 @@ export const LocationView: React.FC = () => {
               </Box>
             }
           >
-            <DeviceTable
-              devices={locationDeviceInfos}
-              renderLink
-              renderLinkToDeviceMessages
-              hideId
-              showDeviceIdentifier
-              canSelectDevices
-              selectedDeviceIdentifiers={selectedDeviceIdentifiers}
-              onSelectedDeviceIdentifiersChange={setSelectedDeviceIdentifiers}
-            />
             {hasMotionControlDevices && (
               <DeviceControlComponent
                 hasMotionSensor={hasMotionControlDevices}
@@ -644,6 +634,16 @@ export const LocationView: React.FC = () => {
                 }}
               />
             )}
+            <DeviceTable
+              devices={locationDeviceInfos}
+              renderLink
+              renderLinkToDeviceMessages
+              hideId
+              showDeviceIdentifier
+              canSelectDevices
+              selectedDeviceIdentifiers={selectedDeviceIdentifiers}
+              onSelectedDeviceIdentifiersChange={setSelectedDeviceIdentifiers}
+            />
           </Collapsible>
 
           {hasMotionControlDevices && (

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
@@ -64,6 +64,9 @@ export const LocationView: React.FC = () => {
   const [locationDeviceInfos, setLocationDeviceInfos] = useState<DeviceInfo[]>(
     [],
   );
+  const [selectedDeviceIdentifiers, setSelectedDeviceIdentifiers] = useState<
+    string[]
+  >([]);
 
   const sensors = useSelector(getSensors);
   const locations = useSelector(getLocations);
@@ -98,6 +101,12 @@ export const LocationView: React.FC = () => {
       .getDeviceInfos([locationId])
       .then((response) => {
         setLocationDeviceInfos(response ?? []);
+        const availableIdentifiers = new Set(
+          (response ?? []).map((deviceInfo) => deviceInfo.device.identifier),
+        );
+        setSelectedDeviceIdentifiers((current) =>
+          current.filter((identifier) => availableIdentifiers.has(identifier)),
+        );
       })
       .catch((error) => {
         console.error(error);
@@ -316,6 +325,24 @@ export const LocationView: React.FC = () => {
       });
   };
 
+  const updateSelectedDeviceAttributes = (
+    attributesByDeviceIdentifier: Record<string, DeviceInfo["attributes"]>,
+  ) => {
+    setLocationDeviceInfos((current) =>
+      current.map((deviceInfo) => {
+        const attributes =
+          attributesByDeviceIdentifier[deviceInfo.device.identifier];
+
+        return attributes
+          ? {
+              ...deviceInfo,
+              attributes,
+            }
+          : deviceInfo;
+      }),
+    );
+  };
+
   const setLocationMotionControlState = (
     state: number,
     message: string,
@@ -359,6 +386,82 @@ export const LocationView: React.FC = () => {
     locationHook
       .setMotionControlDelay(location.identifier, delayMs, executeAt)
       .then(() => {
+        loadLocationDeviceInfos();
+        dispatch(
+          addNotification({
+            title: message,
+            body: "",
+            severity: "success",
+          }),
+        );
+      })
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  const setSelectedDevicesMotionControlState = (
+    state: number,
+    message: string,
+    executeAt?: moment.Moment,
+  ) => {
+    if (!location || selectedDeviceIdentifiers.length === 0) {
+      dispatch(
+        addNotification({
+          title: "Select at least one device",
+          body: "",
+          severity: "warning",
+        }),
+      );
+      return;
+    }
+
+    setIsLoading(true);
+    deviceHook
+      .setMotionControlState(selectedDeviceIdentifiers, state, executeAt)
+      .then((response) => {
+        updateSelectedDeviceAttributes(response);
+        loadLocationDeviceInfos();
+        dispatch(
+          addNotification({
+            title: message,
+            body: "",
+            severity: "success",
+          }),
+        );
+      })
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  const setSelectedDevicesMotionControlDelay = (
+    delayMs: number,
+    message: string,
+    executeAt?: moment.Moment,
+  ) => {
+    if (!location || selectedDeviceIdentifiers.length === 0) {
+      dispatch(
+        addNotification({
+          title: "Select at least one device",
+          body: "",
+          severity: "warning",
+        }),
+      );
+      return;
+    }
+
+    setIsLoading(true);
+    deviceHook
+      .setMotionControlDelay(selectedDeviceIdentifiers, delayMs, executeAt)
+      .then((response) => {
+        updateSelectedDeviceAttributes(response);
         loadLocationDeviceInfos();
         dispatch(
           addNotification({
@@ -507,18 +610,47 @@ export const LocationView: React.FC = () => {
               renderLinkToDeviceMessages
               hideId
               showDeviceIdentifier
+              canSelectDevices
+              selectedDeviceIdentifiers={selectedDeviceIdentifiers}
+              onSelectedDeviceIdentifiersChange={setSelectedDeviceIdentifiers}
             />
+            {hasMotionControlDevices && (
+              <DeviceControlComponent
+                hasMotionSensor={hasMotionControlDevices}
+                disabled={selectedDeviceIdentifiers.length === 0}
+                onSetOutStatic={(mode: boolean, executeAt?: moment.Moment) => {
+                  setSelectedDevicesMotionControlState(
+                    mode ? 1 : 0,
+                    `Outputs set to ${mode} for ${selectedDeviceIdentifiers.length} device(s)`,
+                    executeAt,
+                  );
+                }}
+                onSetOutOnMotionControl={(executeAt?: moment.Moment) => {
+                  setSelectedDevicesMotionControlState(
+                    2,
+                    `Motion control enabled for ${selectedDeviceIdentifiers.length} device(s)`,
+                    executeAt,
+                  );
+                }}
+                onSetMotionControlDelay={(
+                  delay: number,
+                  executeAt?: moment.Moment,
+                ) => {
+                  setSelectedDevicesMotionControlDelay(
+                    delay * 1000,
+                    `Motion control delay set to ${delay} s for ${selectedDeviceIdentifiers.length} device(s)`,
+                    executeAt,
+                  );
+                }}
+              />
+            )}
           </Collapsible>
 
           {hasMotionControlDevices && (
-            <Collapsible title="Commands" isOpen={true}>
+            <Collapsible title="Location Commands" isOpen={true}>
               <DeviceControlComponent
                 hasMotionSensor={hasMotionControlDevices}
-                title="Location commands"
-                onSetOutStatic={(
-                  mode: boolean,
-                  executeAt?: moment.Moment,
-                ) => {
+                onSetOutStatic={(mode: boolean, executeAt?: moment.Moment) => {
                   setLocationMotionControlState(
                     mode ? 1 : 0,
                     `Outputs set to ${mode} for ${location.name}`,

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/containers/LocationView.tsx
@@ -432,6 +432,7 @@ export const LocationView: React.FC = () => {
             severity: "success",
           }),
         );
+        setSelectedDeviceIdentifiers([]);
       })
       .catch((error) => {
         console.error(error);
@@ -470,6 +471,7 @@ export const LocationView: React.FC = () => {
             severity: "success",
           }),
         );
+        setSelectedDeviceIdentifiers([]);
       })
       .catch((error) => {
         console.error(error);

--- a/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
+++ b/src/EnvironmentMonitor.ReactUi/environment-monitor/src/hooks/apiHook.ts
@@ -177,15 +177,15 @@ interface deviceHook {
     getLatestMeasurementBySensor?: boolean,
   ) => Promise<DeviceInfo>;
   setMotionControlState: (
-    identifier: string,
+    identifiers: string | string[],
     state: number,
     executeAt?: moment.Moment,
-  ) => Promise<DeviceAttribute[]>;
+  ) => Promise<Record<string, DeviceAttribute[]>>;
   setMotionControlDelay: (
-    identifier: string,
+    identifiers: string | string[],
     delayMs: number,
     executeAt?: moment.Moment,
-  ) => Promise<DeviceAttribute[]>;
+  ) => Promise<Record<string, DeviceAttribute[]>>;
   getDeviceEvents: (identifier: string) => Promise<DeviceEvent[]>;
   uploadAttachment: (
     identifire: string,
@@ -713,16 +713,19 @@ export const useApiHook = (): ApiHook => {
         }
       },
       setMotionControlState: async (
-        identifier: string,
+        identifiers: string | string[],
         state: number,
         executeAt?: moment.Moment,
       ) => {
         try {
+          const deviceIdentifiers = Array.isArray(identifiers)
+            ? identifiers
+            : [identifiers];
           const res = await apiClient.post<
             any,
-            AxiosResponse<DeviceAttribute[]>
+            AxiosResponse<Record<string, DeviceAttribute[]>>
           >("/api/devices/motion-control-status", {
-            deviceIdentifier: identifier,
+            deviceIdentifiers,
             mode: state,
             executeAt: executeAt
               ? executeAt.format("YYYY-MM-DDTHH:mm:ss")
@@ -732,21 +735,24 @@ export const useApiHook = (): ApiHook => {
         } catch (ex) {
           console.error(ex);
           showError(ex);
-          return [];
+          throw ex;
         }
       },
       setMotionControlDelay: async (
-        identifier: string,
+        identifiers: string | string[],
         delayMs: number,
         executeAt?: moment.Moment,
       ) => {
         try {
+          const deviceIdentifiers = Array.isArray(identifiers)
+            ? identifiers
+            : [identifiers];
           const res = await apiClient.post<
             any,
-            AxiosResponse<DeviceAttribute[]>
+            AxiosResponse<Record<string, DeviceAttribute[]>>
           >("/api/devices/motion-control-delay", {
-            deviceIdentifier: identifier,
-            DelayMs: delayMs,
+            deviceIdentifiers,
+            delayMs,
             executeAt: executeAt
               ? executeAt.format("YYYY-MM-DDTHH:mm:ss")
               : undefined,
@@ -755,7 +761,7 @@ export const useApiHook = (): ApiHook => {
         } catch (ex) {
           console.error(ex);
           showError(ex);
-          return [];
+          throw ex;
         }
       },
       getDeviceEvents: async (identifier: string) => {
@@ -819,7 +825,7 @@ export const useApiHook = (): ApiHook => {
             `/api/devices/default-image`,
             {
               attachmentGuid: attachmentIdentifier,
-              deviceIdentifier: deviceIdentifier,
+              deviceIdentifiers: [deviceIdentifier],
             },
           );
           return res.data;
@@ -983,7 +989,7 @@ export const useApiHook = (): ApiHook => {
             `/api/locations/${identifier}/motion-control-status`,
             {
               mode: state,
-              deviceIdentifier: identifier, // TODO RENAME
+              deviceIdentifiers: [identifier], // TODO RENAME
               executeAt: executeAt
                 ? executeAt.format("YYYY-MM-DDTHH:mm:ss")
                 : undefined,
@@ -1005,7 +1011,7 @@ export const useApiHook = (): ApiHook => {
             `/api/locations/${identifier}/motion-control-delay`,
             {
               delayMs,
-              deviceIdentifier: identifier, // TODO RENAME
+              deviceIdentifiers: [identifier], // TODO RENAME
               executeAt: executeAt
                 ? executeAt.format("YYYY-MM-DDTHH:mm:ss")
                 : undefined,

--- a/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/DevicesController.cs
@@ -44,15 +44,15 @@ namespace EnvironmentMonitor.WebApi.Controllers
 
         [HttpPost("reboot")]
         [Authorize(Roles = "Admin")]
-        public async Task Reboot([FromBody] MessageDeviceModel model) => await _deviceCommandService.Reboot(model.DeviceIdentifier);
+        public async Task Reboot([FromBody] MessageDeviceModel model) => await _deviceCommandService.Reboot(model.DeviceIdentifiers.First());
 
         [HttpPost("motion-control-status")]
         [Authorize(Roles = "Admin")]
-        public async Task<List<DeviceAttributeDto>> SetMotionControlStatus([FromBody] SetMotionControlStatusMessage model) => await _deviceCommandService.SetMotionControlStatus(model.DeviceIdentifier, (MotionControlStatus)model.Mode, model.ExecuteAt);
+        public async Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlStatus([FromBody] SetMotionControlStatusMessage model) => await _deviceCommandService.SetMotionControlStatus(model);
 
         [HttpPost("motion-control-delay")]
         [Authorize(Roles = "Admin")]
-        public async Task<List<DeviceAttributeDto>> SetMotionControlDelay([FromBody] SetMotionControlDelayMessag model) => await _deviceCommandService.SetMotionControlDelay(model.DeviceIdentifier, model.DelayMs, model.ExecuteAt);
+        public async Task<Dictionary<Guid, List<DeviceAttributeDto>>> SetMotionControlDelay([FromBody] SetMotionControlDelayMessage model) => await _deviceCommandService.SetMotionControlDelay(model);
 
         [HttpPost("attachment")]
         [Authorize(Roles = "Admin")]
@@ -105,8 +105,8 @@ namespace EnvironmentMonitor.WebApi.Controllers
         [Authorize(Roles = "Admin")]
         public async Task<DeviceInfoDto> SetDefaultImage([FromBody] SetDefaultImage model)
         {
-            await _deviceService.SetDefaultImage(model.DeviceIdentifier, model.AttachmentGuid);
-            var res = await _deviceService.GetDeviceInfos(false, [model.DeviceIdentifier], true);
+            await _deviceService.SetDefaultImage(model.DeviceIdentifiers.First(), model.AttachmentGuid);
+            var res = await _deviceService.GetDeviceInfos(false, [model.DeviceIdentifiers.First()], true);
             return res.FirstOrDefault();
         }
 

--- a/src/EnvironmentMonitor.WebApi/Controllers/LocationsController.cs
+++ b/src/EnvironmentMonitor.WebApi/Controllers/LocationsController.cs
@@ -97,7 +97,7 @@ namespace EnvironmentMonitor.WebApi.Controllers
 
         [HttpPost("{locationIdentifier}/motion-control-delay")]
         [Authorize(Roles = "Admin")]
-        public async Task SetLocationMotionControlDelay([FromRoute] Guid locationIdentifier, [FromBody] SetMotionControlDelayMessag model)
+        public async Task SetLocationMotionControlDelay([FromRoute] Guid locationIdentifier, [FromBody] SetMotionControlDelayMessage model)
             => await _locationCommandService.SetMotionControlDelay(locationIdentifier, model.DelayMs, model.ExecuteAt);
     }
 }


### PR DESCRIPTION
Support for sending commands to multiple devices

- Backend end points for setting device output mode & delay now take an array of device identifiers instead of a single value.
- Added wrapper methods which call the old methods which set commands for a single device
- Mode / delay can be set for multiple devices in LocationView
- DeviceTable has a prop which make it possible to select devices