### PR TITLE
Support Hangfire for background jobs, filtering options for syncing

### DIFF
--- a/.github/workflows/main_env-monitor.yml
+++ b/.github/workflows/main_env-monitor.yml
@@ -76,6 +76,10 @@ jobs:
           dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r win-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-function_x64"
           dotnet publish src/EnvironmentMonitor.HubObserver/EnvironmentMonitor.HubObserver.csproj -c Release -r linux-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-function_linux-x64"
 
+      - name: Publish Worker (LINUX-X64)
+        run: |
+          dotnet publish src/EnvironmentMonitor.Worker/EnvironmentMonitor.Worker.csproj -c Release -r linux-x64 -o "${{env.DOTNET_ROOT}}/env-monitor-worker_linux-x64"
+
       - name: Upload web api artifact (win-x86)
         uses: actions/upload-artifact@v4
         with:
@@ -107,6 +111,12 @@ jobs:
           name: .env-monitor-function_x64
           path: ${{env.DOTNET_ROOT}}/env-monitor-function_x64
           include-hidden-files: true
+
+      - name: Upload worker artifact (linux-x64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: .env-monitor-worker_linux-x64
+          path: ${{env.DOTNET_ROOT}}/env-monitor-worker_linux-x64
   deploy:
     runs-on: windows-latest
     needs: build

--- a/EnvironmentMonitor.sln
+++ b/EnvironmentMonitor.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnvironmentMonitor.UnitTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnvironmentMonitor.PostgreSqlMigrations", "src\EnvironmentMonitor.PostgreSqlMigrations\EnvironmentMonitor.PostgreSqlMigrations.csproj", "{A55EF436-0B92-44D9-AFCE-2D87ED6BD938}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnvironmentMonitor.Worker", "src\EnvironmentMonitor.Worker\EnvironmentMonitor.Worker.csproj", "{CF6F91A3-876B-47F8-92C2-D77209831AF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{A55EF436-0B92-44D9-AFCE-2D87ED6BD938}.Release|x64.Build.0 = Release|Any CPU
 		{A55EF436-0B92-44D9-AFCE-2D87ED6BD938}.Release|x86.ActiveCfg = Release|Any CPU
 		{A55EF436-0B92-44D9-AFCE-2D87ED6BD938}.Release|x86.Build.0 = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|x64.Build.0 = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +171,7 @@ Global
 		{BEE69CC8-3087-45C8-A2CB-4D0D86BEC02D} = {95C17B13-0784-4421-BEEF-A135420C4FE5}
 		{C4C58D7E-DF86-47B5-8044-009FE1FB9A3B} = {95C17B13-0784-4421-BEEF-A135420C4FE5}
 		{A55EF436-0B92-44D9-AFCE-2D87ED6BD938} = {8EED74DA-71D0-4CA1-AB3B-1617DF063130}
+		{CF6F91A3-876B-47F8-92C2-D77209831AF5} = {8EED74DA-71D0-4CA1-AB3B-1617DF063130}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAA34A12-E649-4C92-BEC9-EBA36852FA91}

--- a/src/EnvironmentMonitor.Application/Services/SyncService.cs
+++ b/src/EnvironmentMonitor.Application/Services/SyncService.cs
@@ -74,8 +74,11 @@ namespace EnvironmentMonitor.Application.Services
 
                 _logger.LogInformation($"Starting sync from DeviceMessage ID: {lastSyncedId}");
 
-                // Get unsynced device messages
-                var unsyncedMessages = await _statusVariableRepository.GetUnsyncedDeviceMessages(lastSyncedId, _syncSettings.BatchSize);
+                // Get unsynced device messages with optional filtering by communication channels
+                var unsyncedMessages = await _statusVariableRepository.GetUnsyncedDeviceMessages(
+                    lastSyncedId, 
+                    _syncSettings.BatchSize, 
+                    _syncSettings.ExcludedCommunicationChannels);
 
                 if (!unsyncedMessages.Any())
                 {

--- a/src/EnvironmentMonitor.Application/Services/UserService.cs
+++ b/src/EnvironmentMonitor.Application/Services/UserService.cs
@@ -24,6 +24,7 @@ namespace EnvironmentMonitor.Application.Services
         private readonly IQueueClient _queueClient;
         private readonly IMapper _mapper;
         private readonly IUserCookieService _userCookieService;
+        private readonly IHangfireJobService _hangfireJobService;
 
         public UserService(
             ICurrentUser currentUser,
@@ -31,7 +32,8 @@ namespace EnvironmentMonitor.Application.Services
             ApplicationSettings applicationSettings,
             IQueueClient queueClient,
             IMapper mapper,
-            IUserCookieService userCookieService)
+            IUserCookieService userCookieService,
+            IHangfireJobService hangfireJobService)
         {
             _currentUser = currentUser;
             _userAuthService = userAuthService;
@@ -39,6 +41,7 @@ namespace EnvironmentMonitor.Application.Services
             _queueClient = queueClient;
             _mapper = mapper;
             _userCookieService = userCookieService;
+            _hangfireJobService = hangfireJobService;
         }
 
         public bool HasAccessToDevice(Guid id, AccessLevels accessLevel) => HasAccessTo(EntityRoles.Device, id, accessLevel);
@@ -143,6 +146,17 @@ namespace EnvironmentMonitor.Application.Services
         {
             if (model.Enqueue)
             {
+                // Try to enqueue with Hangfire first if available
+                if (_hangfireJobService.IsAvailable)
+                {
+                    var baseUrl = string.IsNullOrEmpty(model.BaseUrl) ? _applicationSettings.BaseUrl : model.BaseUrl;
+                    model.BaseUrl = baseUrl;
+
+                    _hangfireJobService.Enqueue<IUserAuthService>(service => service.ForgotPassword(model));
+                    return;
+                }
+
+                // Fallback to queue client if Hangfire is not available
                 var attributesToAdd = new Dictionary<string, string>()
                 {
                         {ApplicationConstants.QueuedMessageDefaultKey, model.Email },

--- a/src/EnvironmentMonitor.Domain/Interfaces/IHangfireJobService.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IHangfireJobService.cs
@@ -1,0 +1,42 @@
+using System.Linq.Expressions;
+
+namespace EnvironmentMonitor.Domain.Interfaces
+{
+    /// <summary>
+    /// Service for enqueuing background jobs with Hangfire.
+    /// Provides a clean abstraction over Hangfire job execution.
+    /// </summary>
+    public interface IHangfireJobService
+    {
+        /// <summary>
+        /// Enqueues a fire-and-forget job to be executed immediately in the background.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <returns>Job ID</returns>
+        string Enqueue<TService>(Expression<Func<TService, Task>> methodCall);
+
+        /// <summary>
+        /// Enqueues a delayed job to be executed after a specified delay.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <param name="delay">Time to wait before executing the job</param>
+        /// <returns>Job ID</returns>
+        string Schedule<TService>(Expression<Func<TService, Task>> methodCall, TimeSpan delay);
+
+        /// <summary>
+        /// Enqueues a delayed job to be executed at a specific time.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <param name="enqueueAt">DateTime when the job should be executed</param>
+        /// <returns>Job ID</returns>
+        string Schedule<TService>(Expression<Func<TService, Task>> methodCall, DateTimeOffset enqueueAt);
+
+        /// <summary>
+        /// Checks if Hangfire is available and configured.
+        /// </summary>
+        bool IsAvailable { get; }
+    }
+}

--- a/src/EnvironmentMonitor.Domain/Interfaces/IStatusVariableRepository.cs
+++ b/src/EnvironmentMonitor.Domain/Interfaces/IStatusVariableRepository.cs
@@ -22,6 +22,6 @@ namespace EnvironmentMonitor.Domain.Interfaces
         /// <summary>
         /// Gets unsynced device messages with related data for sync operation
         /// </summary>
-        Task<List<DeviceMessage>> GetUnsyncedDeviceMessages(long lastSyncedId, int batchSize);
+        Task<List<DeviceMessage>> GetUnsyncedDeviceMessages(long lastSyncedId, int batchSize, List<int>? excludedCommunicationChannels = null);
     }
 }

--- a/src/EnvironmentMonitor.Domain/Models/HangfireJobSchedules.cs
+++ b/src/EnvironmentMonitor.Domain/Models/HangfireJobSchedules.cs
@@ -1,0 +1,11 @@
+namespace EnvironmentMonitor.Domain.Models
+{
+    /// <summary>
+    /// Configuration for all Hangfire recurring jobs.
+    /// Key matches the configuration key in appsettings.json under "HangfireJobs".
+    /// </summary>
+    public class HangfireJobSchedules
+    {
+        public string FmiSyncSchedule { get; set; } = "*/5 * * * *";
+    }
+}

--- a/src/EnvironmentMonitor.Domain/Models/SyncSettings.cs
+++ b/src/EnvironmentMonitor.Domain/Models/SyncSettings.cs
@@ -34,5 +34,10 @@ namespace EnvironmentMonitor.Domain.Models
         /// Maximum number of messages to sync in one batch (default: 40)
         /// </summary>
         public int BatchSize { get; set; } = 40;
+
+        /// <summary>
+        /// CommunicationChannel IDs to exclude from sync. If empty or null, all channels are included.
+        /// </summary>
+        public List<int> ExcludedCommunicationChannels { get; set; } = new List<int>();
     }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Data/StatusVariableRepository.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Data/StatusVariableRepository.cs
@@ -48,13 +48,22 @@ namespace EnvironmentMonitor.Infrastructure.Data
             await _context.SaveChangesAsync();
         }
 
-        public async Task<List<DeviceMessage>> GetUnsyncedDeviceMessages(long lastSyncedId, int batchSize)
+        public async Task<List<DeviceMessage>> GetUnsyncedDeviceMessages(long lastSyncedId, int batchSize, List<int>? excludedCommunicationChannels = null)
         {
-            return await _context.DeviceMessages
+            var query = _context.DeviceMessages
                 .Include(dm => dm.Device)
                 .Include(dm => dm.Measurements)
                     .ThenInclude(m => m.Sensor)
-                .Where(dm => dm.Id > lastSyncedId && !dm.IsDuplicate)
+                .Include(dm => dm.CommunicationChannel)
+                .Where(dm => dm.Id > lastSyncedId && !dm.IsDuplicate);
+
+            // Filter out excluded communication channels if specified
+            if (excludedCommunicationChannels != null && excludedCommunicationChannels.Any())
+            {
+                query = query.Where(dm => dm.SourceId == null || !excludedCommunicationChannels.Contains(dm.SourceId.Value));
+            }
+
+            return await query
                 .OrderBy(dm => dm.Id)
                 .Take(batchSize)
                 .ToListAsync();

--- a/src/EnvironmentMonitor.Infrastructure/EnvironmentMonitor.Infrastructure.csproj
+++ b/src/EnvironmentMonitor.Infrastructure/EnvironmentMonitor.Infrastructure.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.20" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.21.0" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.20" />
     <PackageReference Include="LinqKit" Version="1.3.11" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.15.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />

--- a/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -290,7 +290,6 @@ namespace EnvironmentMonitor.Infrastructure.Extensions
             if (databaseProvider.Equals(DatabaseSettings.PostgreSql, StringComparison.OrdinalIgnoreCase))
             {
                 services.AddHangfire(config => config
-                    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
                     .UseSimpleAssemblyNameTypeSerializer()
                     .UseRecommendedSerializerSettings()
                     .UsePostgreSqlStorage(options =>

--- a/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,9 @@ using EnvironmentMonitor.Domain.Models;
 using EnvironmentMonitor.Infrastructure.Data;
 using EnvironmentMonitor.Infrastructure.Identity;
 using EnvironmentMonitor.Infrastructure.Services;
+using Hangfire;
+using Hangfire.PostgreSql;
+using Hangfire.SqlServer;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -254,6 +257,65 @@ namespace EnvironmentMonitor.Infrastructure.Extensions
 
             throw new InvalidOperationException(
                 $"Unsupported database provider '{databaseProvider}'. Use '{DatabaseSettings.SqlServer}' or '{DatabaseSettings.PostgreSql}'.");
+        }
+
+        public static IServiceCollection AddHangfireServices(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            string? hangfireConnectionString = null,
+            DatabaseSettings? databaseSettings = null,
+            bool addServer = true)
+        {
+            var hangfireConnectionStringToUse = hangfireConnectionString ?? configuration.GetConnectionString("HangfireConnection");
+
+            if (string.IsNullOrWhiteSpace(hangfireConnectionStringToUse))
+            {
+                throw new InvalidOperationException("Hangfire connection string 'HangfireConnection' is not configured.");
+            }
+
+            DatabaseSettings databaseSettingsToUse;
+            if (databaseSettings != null)
+            {
+                databaseSettingsToUse = databaseSettings;
+            }
+            else
+            {
+                databaseSettingsToUse = new DatabaseSettings();
+                configuration.GetSection("DatabaseSettings").Bind(databaseSettingsToUse);
+            }
+
+            var databaseProvider = databaseSettingsToUse.Provider;
+
+            // Configure Hangfire storage based on database provider
+            if (databaseProvider.Equals(DatabaseSettings.PostgreSql, StringComparison.OrdinalIgnoreCase))
+            {
+                services.AddHangfire(config => config
+                    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+                    .UseSimpleAssemblyNameTypeSerializer()
+                    .UseRecommendedSerializerSettings()
+                    .UsePostgreSqlStorage(options =>
+                        options.UseNpgsqlConnection(hangfireConnectionStringToUse)));
+            }
+            else if (databaseProvider.Equals(DatabaseSettings.SqlServer, StringComparison.OrdinalIgnoreCase))
+            {
+                services.AddHangfire(config => config
+                    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+                    .UseSimpleAssemblyNameTypeSerializer()
+                    .UseRecommendedSerializerSettings()
+                    .UseSqlServerStorage(hangfireConnectionStringToUse));
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Unsupported database provider '{databaseProvider}' for Hangfire. Use '{DatabaseSettings.SqlServer}' or '{DatabaseSettings.PostgreSql}'.");
+            }
+
+            if (addServer)
+            {
+                services.AddHangfireServer();
+            }
+
+            return services;
         }
     }
 }

--- a/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -141,6 +141,7 @@ namespace EnvironmentMonitor.Infrastructure.Extensions
 
             services.AddScoped<IRoleManager, RoleManager>();
             services.AddScoped<IUserAuthService, UserAuthService>();
+            services.AddScoped<IHangfireJobService, HangfireJobService>();
 
             if (iotHubSettings != null)
             {

--- a/src/EnvironmentMonitor.Infrastructure/Services/HangfireJobService.cs
+++ b/src/EnvironmentMonitor.Infrastructure/Services/HangfireJobService.cs
@@ -1,0 +1,122 @@
+using EnvironmentMonitor.Domain.Interfaces;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using System.Linq.Expressions;
+
+namespace EnvironmentMonitor.Infrastructure.Services
+{
+    /// <summary>
+    /// Service for enqueuing background jobs with Hangfire.
+    /// Provides a clean abstraction that falls back gracefully if Hangfire is not configured.
+    /// </summary>
+    public class HangfireJobService : IHangfireJobService
+    {
+        private readonly IBackgroundJobClient? _backgroundJobClient;
+        private readonly ILogger<HangfireJobService> _logger;
+
+        public HangfireJobService(
+            ILogger<HangfireJobService> logger,
+            IBackgroundJobClient? backgroundJobClient = null)
+        {
+            _logger = logger;
+            _backgroundJobClient = backgroundJobClient;
+        }
+
+        /// <summary>
+        /// Checks if Hangfire is available and configured.
+        /// </summary>
+        public bool IsAvailable => _backgroundJobClient != null;
+
+        /// <summary>
+        /// Enqueues a fire-and-forget job to be executed immediately in the background.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <returns>Job ID, or empty string if Hangfire is not available</returns>
+        /// <example>
+        /// jobService.Enqueue&lt;IUserAuthService&gt;(service => service.ForgotPassword(model));
+        /// </example>
+        public string Enqueue<TService>(Expression<Func<TService, Task>> methodCall)
+        {
+            if (_backgroundJobClient == null)
+            {
+                _logger.LogError("Hangfire is not configured. Job will not be enqueued: {MethodCall}", methodCall);
+                throw new InvalidOperationException("Hangfire is not configured. Cannot enqueue job.");
+            }
+
+            try
+            {
+                var jobId = _backgroundJobClient.Enqueue(methodCall);
+                _logger.LogInformation("Job enqueued successfully. Job ID: {JobId}", jobId);
+                return jobId;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to enqueue Hangfire job");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Enqueues a delayed job to be executed after a specified delay.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <param name="delay">Time to wait before executing the job</param>
+        /// <returns>Job ID, or empty string if Hangfire is not available</returns>
+        /// <example>
+        /// jobService.Schedule&lt;IEmailService&gt;(service => service.SendEmail(email), TimeSpan.FromMinutes(5));
+        /// </example>
+        public string Schedule<TService>(Expression<Func<TService, Task>> methodCall, TimeSpan delay)
+        {
+            if (_backgroundJobClient == null)
+            {
+                _logger.LogWarning("Hangfire is not configured. Scheduled job will not be enqueued: {MethodCall}", methodCall);
+                return string.Empty;
+            }
+
+            try
+            {
+                var jobId = _backgroundJobClient.Schedule(methodCall, delay);
+                _logger.LogInformation("Job scheduled successfully for {Delay}. Job ID: {JobId}", delay, jobId);
+                return jobId;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to schedule Hangfire job");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Enqueues a delayed job to be executed at a specific time.
+        /// </summary>
+        /// <typeparam name="TService">The service type containing the method to execute</typeparam>
+        /// <param name="methodCall">Expression pointing to the method to execute</param>
+        /// <param name="enqueueAt">DateTime when the job should be executed</param>
+        /// <returns>Job ID, or empty string if Hangfire is not available</returns>
+        /// <example>
+        /// jobService.Schedule&lt;IReportService&gt;(service => service.GenerateReport(), DateTimeOffset.UtcNow.AddHours(2));
+        /// </example>
+        public string Schedule<TService>(Expression<Func<TService, Task>> methodCall, DateTimeOffset enqueueAt)
+        {
+            if (_backgroundJobClient == null)
+            {
+                _logger.LogWarning("Hangfire is not configured. Scheduled job will not be enqueued: {MethodCall}", methodCall);
+                return string.Empty;
+            }
+
+            try
+            {
+                var jobId = _backgroundJobClient.Schedule(methodCall, enqueueAt);
+                _logger.LogInformation("Job scheduled successfully for {EnqueueAt}. Job ID: {JobId}", enqueueAt, jobId);
+                return jobId;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to schedule Hangfire job");
+                throw;
+            }
+        }
+    }
+}

--- a/src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj
+++ b/src/EnvironmentMonitor.WebApi/EnvironmentMonitor.WebApi.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.10" />

--- a/src/EnvironmentMonitor.WebApi/Filters/HangfireAuthorizationFilter.cs
+++ b/src/EnvironmentMonitor.WebApi/Filters/HangfireAuthorizationFilter.cs
@@ -1,0 +1,20 @@
+using EnvironmentMonitor.Domain.Enums;
+using Hangfire.Dashboard;
+
+namespace EnvironmentMonitor.WebApi.Filters
+{
+    public class HangfireAuthorizationFilter : IDashboardAuthorizationFilter
+    {
+        public bool Authorize(DashboardContext context)
+        {
+            var httpContext = context.GetHttpContext();
+
+            if (httpContext.User?.Identity?.IsAuthenticated == true)
+            {
+                return httpContext.User.IsInRole(GlobalRoles.Admin.ToString());
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EnvironmentMonitor.WebApi/Program.cs
+++ b/src/EnvironmentMonitor.WebApi/Program.cs
@@ -8,6 +8,7 @@ using EnvironmentMonitor.Infrastructure.Identity;
 using EnvironmentMonitor.WebApi.Authentication;
 using EnvironmentMonitor.WebApi.Filters;
 using EnvironmentMonitor.WebApi.Services;
+using Hangfire;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
@@ -49,7 +50,18 @@ applicationSettings.IsProduction = builder.Environment.IsProduction();
 
 builder.Services.AddInfrastructureServices(builder.Configuration, applicationSettings: applicationSettings);
 builder.Services.AddApplicationServices(builder.Configuration);
-// Add API Key authentication scheme 
+
+// Add Hangfire services (client only - server runs in Worker)
+var hangfireConnectionString = builder.Configuration.GetConnectionString("HangfireConnection");
+if (!string.IsNullOrEmpty(hangfireConnectionString))
+{
+    builder.Services.AddHangfireServices(
+        builder.Configuration, 
+        hangfireConnectionString: hangfireConnectionString, 
+        addServer: false);
+}
+
+// Add API Key authentication scheme
 builder.Services.AddAuthentication()
     .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(
         ApiKeyAuthenticationOptions.DefaultScheme, 
@@ -241,6 +253,16 @@ app.UseStaticFiles();
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Add Hangfire Dashboard (only accessible in Development for now)
+if (app.Environment.IsDevelopment())
+{
+    var hangfireConn = app.Configuration.GetConnectionString("HangfireConnection");
+    if (!string.IsNullOrEmpty(hangfireConn))
+    {
+        app.UseHangfireDashboard("/hangfire");
+    }
+}
 
 app.MapControllers();
 

--- a/src/EnvironmentMonitor.WebApi/Program.cs
+++ b/src/EnvironmentMonitor.WebApi/Program.cs
@@ -254,14 +254,15 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-// Add Hangfire Dashboard (only accessible in Development for now)
-if (app.Environment.IsDevelopment())
+if (!string.IsNullOrEmpty(hangfireConnectionString))
 {
-    var hangfireConn = app.Configuration.GetConnectionString("HangfireConnection");
-    if (!string.IsNullOrEmpty(hangfireConn))
+    app.UseHangfireDashboard("/hangfire", new DashboardOptions
     {
-        app.UseHangfireDashboard("/hangfire");
-    }
+        Authorization = new[] { new HangfireAuthorizationFilter() },
+        DashboardTitle = "EnvironmentMonitor - Job Dashboard",
+        DisplayStorageConnectionString = app.Environment.IsDevelopment(),
+        StatsPollingInterval = 5000
+    });
 }
 
 app.MapControllers();

--- a/src/EnvironmentMonitor.WebApi/appsettings.json
+++ b/src/EnvironmentMonitor.WebApi/appsettings.json
@@ -14,7 +14,8 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "-"
+    "DefaultConnection": "",
+    "HangfireConnection": ""
   },
   "DatabaseSettings": {
     "Provider": "SqlServer"

--- a/src/EnvironmentMonitor.Worker/EnvironmentMonitor.Worker.csproj
+++ b/src/EnvironmentMonitor.Worker/EnvironmentMonitor.Worker.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>a7c2f3b9-5d8e-4f1a-9c7b-2e6d8f4a1b3c</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EnvironmentMonitor.Application\EnvironmentMonitor.Application.csproj" />
+    <ProjectReference Include="..\EnvironmentMonitor.Infrastructure\EnvironmentMonitor.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EnvironmentMonitor.Worker/EnvironmentMonitor.Worker.csproj
+++ b/src/EnvironmentMonitor.Worker/EnvironmentMonitor.Worker.csproj
@@ -8,7 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.10" />
   </ItemGroup>

--- a/src/EnvironmentMonitor.Worker/Jobs/FmiMeasurementSyncJob.cs
+++ b/src/EnvironmentMonitor.Worker/Jobs/FmiMeasurementSyncJob.cs
@@ -1,0 +1,41 @@
+using EnvironmentMonitor.Application.Interfaces;
+using Hangfire;
+
+namespace EnvironmentMonitor.Worker.Jobs
+{
+    /// <summary>
+    /// Hangfire job for syncing FMI weather measurement data.
+    /// DisableConcurrentExecution prevents multiple instances from running simultaneously.
+    /// </summary>
+    
+    public class FmiMeasurementSyncJob
+    {
+        private readonly IFmiMeasurementService _fmiMeasurementService;
+        private readonly ILogger<FmiMeasurementSyncJob> _logger;
+
+        public FmiMeasurementSyncJob(
+            IFmiMeasurementService fmiMeasurementService,
+            ILogger<FmiMeasurementSyncJob> logger)
+        {
+            _fmiMeasurementService = fmiMeasurementService;
+            _logger = logger;
+        }
+
+        [DisableConcurrentExecution(timeoutInSeconds: 300)]
+        public async Task Execute()
+        {
+            _logger.LogInformation("FMI measurement sync job started at: {Time}", DateTimeOffset.UtcNow);
+
+            try
+            {
+                await _fmiMeasurementService.SyncData();
+                _logger.LogInformation("FMI measurement sync job completed successfully at: {Time}", DateTimeOffset.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during FMI measurement sync job");
+                throw; // Re-throw to let Hangfire handle retry logic
+            }
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Worker/Program.cs
+++ b/src/EnvironmentMonitor.Worker/Program.cs
@@ -1,0 +1,37 @@
+using EnvironmentMonitor.Application.Extensions;
+using EnvironmentMonitor.Domain.Interfaces;
+using EnvironmentMonitor.Infrastructure.Extensions;
+using EnvironmentMonitor.Worker;
+using EnvironmentMonitor.Worker.Services;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Register CurrentUser service for background job context
+builder.Services.AddSingleton<ICurrentUser, CurrentUser>();
+
+// Configure connection strings and database settings
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+var hangfireConnectionString = builder.Configuration.GetConnectionString("HangfireConnection");
+
+// Add Infrastructure services
+builder.Services.AddInfrastructureServices(
+    builder.Configuration,
+    connectionString: connectionString);
+
+// Add Application services
+builder.Services.AddApplicationServices(builder.Configuration);
+
+// Add Hangfire services (includes server for job processing)
+builder.Services.AddHangfireServices(
+    builder.Configuration,
+    hangfireConnectionString: hangfireConnectionString,
+    addServer: true);
+
+// Add Worker service
+builder.Services.AddHostedService<Worker>();
+
+// Add systemd support for running as Linux service
+builder.Services.AddSystemd();
+
+var host = builder.Build();
+host.Run();

--- a/src/EnvironmentMonitor.Worker/Program.cs
+++ b/src/EnvironmentMonitor.Worker/Program.cs
@@ -2,36 +2,40 @@ using EnvironmentMonitor.Application.Extensions;
 using EnvironmentMonitor.Domain.Interfaces;
 using EnvironmentMonitor.Infrastructure.Extensions;
 using EnvironmentMonitor.Worker;
+using EnvironmentMonitor.Worker.Jobs;
 using EnvironmentMonitor.Worker.Services;
+using Hangfire;
 
 var builder = Host.CreateApplicationBuilder(args);
 
 // Register CurrentUser service for background job context
 builder.Services.AddSingleton<ICurrentUser, CurrentUser>();
 
-// Configure connection strings and database settings
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-var hangfireConnectionString = builder.Configuration.GetConnectionString("HangfireConnection");
-
 // Add Infrastructure services
-builder.Services.AddInfrastructureServices(
-    builder.Configuration,
-    connectionString: connectionString);
+builder.Services.AddInfrastructureServices(builder.Configuration);
 
 // Add Application services
 builder.Services.AddApplicationServices(builder.Configuration);
 
 // Add Hangfire services (includes server for job processing)
-builder.Services.AddHangfireServices(
-    builder.Configuration,
-    hangfireConnectionString: hangfireConnectionString,
-    addServer: true);
+builder.Services.AddHangfireServices(builder.Configuration, addServer: true);
 
-// Add Worker service
+// Register Hangfire job classes
+builder.Services.AddScoped<FmiMeasurementSyncJob>();
+
+// Add KeepAlive background service
 builder.Services.AddHostedService<Worker>();
 
 // Add systemd support for running as Linux service
 builder.Services.AddSystemd();
 
 var host = builder.Build();
+
+// Register all recurring Hangfire jobs using DI
+using (var scope = host.Services.CreateScope())
+{
+    var recurringJobManager = scope.ServiceProvider.GetRequiredService<IRecurringJobManager>();
+    HangfireJobRegistration.RegisterJobs(builder.Configuration, recurringJobManager);
+}
+
 host.Run();

--- a/src/EnvironmentMonitor.Worker/Properties/launchSettings.json
+++ b/src/EnvironmentMonitor.Worker/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "EnvironmentMonitor.Worker": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/EnvironmentMonitor.Worker/Services/CurrentUser.cs
+++ b/src/EnvironmentMonitor.Worker/Services/CurrentUser.cs
@@ -1,0 +1,15 @@
+using EnvironmentMonitor.Domain.Enums;
+using EnvironmentMonitor.Domain.Interfaces;
+using System.Security.Claims;
+
+namespace EnvironmentMonitor.Worker.Services
+{
+    public class CurrentUser : ICurrentUser
+    {
+        public string Email => "Worker@Worker.service";
+
+        public List<Claim> Claims => [new(ClaimTypes.Role.ToString(), GlobalRoles.Admin.ToString())];
+
+        public List<string> Roles => [GlobalRoles.Admin.ToString()];
+    }
+}

--- a/src/EnvironmentMonitor.Worker/Services/HangfireJobRegistration.cs
+++ b/src/EnvironmentMonitor.Worker/Services/HangfireJobRegistration.cs
@@ -1,0 +1,34 @@
+using EnvironmentMonitor.Domain.Models;
+using EnvironmentMonitor.Worker.Jobs;
+using Hangfire;
+
+namespace EnvironmentMonitor.Worker.Services
+{
+    /// <summary>
+    /// Service responsible for registering all Hangfire recurring jobs.
+    /// Job schedules are configured in HangfireJobSchedules class.
+    /// </summary>
+    public static class HangfireJobRegistration
+    {
+        // Hangfire job identifiers
+        private const string FmiMeasurementSyncJobId = "fmi-measurement-sync";
+
+        /// <summary>
+        /// Registers all recurring Hangfire jobs with their schedules.
+        /// Reads schedules from HangfireJobs section in configuration.
+        /// </summary>
+        /// <param name="configuration">Application configuration to read schedules from</param>
+        /// <param name="recurringJobManager">Hangfire recurring job manager from DI</param>
+        public static void RegisterJobs(IConfiguration configuration, IRecurringJobManager recurringJobManager)
+        {
+            // Bind job schedules from configuration
+            var schedules = new HangfireJobSchedules();
+            configuration.GetSection("HangfireJobs").Bind(schedules);
+
+            recurringJobManager.AddOrUpdate<FmiMeasurementSyncJob>(
+                FmiMeasurementSyncJobId,
+                job => job.Execute(),
+                schedules.FmiSyncSchedule);
+        }
+    }
+}

--- a/src/EnvironmentMonitor.Worker/Worker.cs
+++ b/src/EnvironmentMonitor.Worker/Worker.cs
@@ -11,15 +11,18 @@ public class Worker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("EnvironmentMonitor Worker starting at: {time}", DateTimeOffset.Now);
+        _logger.LogInformation("EnvironmentMonitor Worker started at: {time}", DateTimeOffset.UtcNow);
+        _logger.LogInformation("Hangfire server is processing background jobs");
 
-        while (!stoppingToken.IsCancellationRequested)
+        try
         {
-            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-
-            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            // Keep the service alive - Hangfire handles all job processing
+            await Task.Delay(Timeout.Infinite, stoppingToken);
         }
-
-        _logger.LogInformation("EnvironmentMonitor Worker stopping at: {time}", DateTimeOffset.Now);
+        catch (TaskCanceledException)
+        {
+            // Expected when service is stopping
+            _logger.LogInformation("EnvironmentMonitor Worker stopping at: {time}", DateTimeOffset.UtcNow);
+        }
     }
 }

--- a/src/EnvironmentMonitor.Worker/Worker.cs
+++ b/src/EnvironmentMonitor.Worker/Worker.cs
@@ -1,0 +1,25 @@
+namespace EnvironmentMonitor.Worker;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("EnvironmentMonitor Worker starting at: {time}", DateTimeOffset.Now);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+
+        _logger.LogInformation("EnvironmentMonitor Worker stopping at: {time}", DateTimeOffset.Now);
+    }
+}

--- a/src/EnvironmentMonitor.Worker/appsettings.Development.json
+++ b/src/EnvironmentMonitor.Worker/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/src/EnvironmentMonitor.Worker/appsettings.json
+++ b/src/EnvironmentMonitor.Worker/appsettings.json
@@ -6,10 +6,25 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "-",
-    "HangfireConnection": "-"
+    "DefaultConnection": "",
+    "HangfireConnection": ""
   },
   "DatabaseSettings": {
     "Provider": "SqlServer"
+  },
+  "ApplicationSettings": {
+    "BaseUrl": "",
+    "TimeZones": [ "FLE Standard Time", "Europe/Helsinki" ]
+  },
+  "DataProtectionKeysSettings": {
+    "StoreInDatabase": false,
+    "EncryptWithKeyVault": false,
+    "KeyVaultKeyIdentifier": "",
+    "TenantId": "",
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "HangfireJobs": {
+    "FmiSyncSchedule": "*/5 * * * *"
   }
 }

--- a/src/EnvironmentMonitor.Worker/appsettings.json
+++ b/src/EnvironmentMonitor.Worker/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "-",
+    "HangfireConnection": "-"
+  },
+  "DatabaseSettings": {
+    "Provider": "SqlServer"
+  }
+}


### PR DESCRIPTION
Added support for Hangfire. For Hangfire integration, added a new Worker-project. It can be run as a service and is used to run Hangfire jobs. WebApi is supposed to trigger the jobs.

- Hangfire can be used to enqueue email sending
- Hangfire can now be used to fetch FMI measurements
- Added functionality for filtering the selected communication channels in syncing jobs